### PR TITLE
Added buttons to create decoder, rules, and kvdbs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All notable changes to the Wazuh ML Commons project will be documented in this f
 - Support for Wazuh 5.0.0
 - Added KVDBs management feature with detailed views [#24](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/24) [#30](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/30) [#37](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/37) [#46](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/46)
 - Added Decoders management feature [#27](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/27) [#30](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/30) [#37](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/37) [#46](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/46) [#41](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/41) [#48](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/48)
-- Added Integrations management feature [#40](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/40) [#48](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/48) [#83](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/83/)
+- Added Integrations management feature [#40](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/40) [#48](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/48) [#64](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/64) [#71](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/71) [#72](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/72) [#86](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/86) [#83](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/83/)
 - Added Log test feature [#43](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/43)
+- Added space persistence when navigate [#63](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/63)
 
 ### Changed
 

--- a/public/hooks/useSpaceFilter.ts
+++ b/public/hooks/useSpaceFilter.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Wazuh Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { useEffect, useMemo } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import { SpaceTypes } from '../../common/constants';
+
+const SPACE_FILTER_KEY = 'security_analytics_space_filter';
+
+export const useSpaceFilter = () => {
+  const location = useLocation();
+  const history = useHistory();
+
+  const spaceFilter = useMemo(
+    () =>
+      new URLSearchParams(location.search).get('space') ||
+      localStorage?.getItem(SPACE_FILTER_KEY) ||
+      SpaceTypes.STANDARD.value,
+    [location.search]
+  );
+
+  // Add space param to URL if missing
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (!params.has('space')) {
+      params.set('space', spaceFilter);
+      history.replace({ ...location, search: params.toString() });
+    }
+  }, [location.pathname]);
+
+  // Persist to localStorage for cross-page navigation fallback
+  useEffect(() => {
+    localStorage?.setItem(SPACE_FILTER_KEY, spaceFilter);
+  }, [spaceFilter]);
+
+  const setSpaceFilter = (id: string) => {
+    const params = new URLSearchParams(location.search);
+    params.set('space', id);
+    history.replace({ ...location, search: params.toString() });
+    localStorage?.setItem(SPACE_FILTER_KEY, id);
+  };
+
+  return [spaceFilter, setSpaceFilter] as const;
+};

--- a/public/hooks/useSpaceSelector.tsx
+++ b/public/hooks/useSpaceSelector.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Wazuh Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import React, { useCallback } from 'react';
+import { SpaceSelector } from '../components/SpaceSelector/SpaceSelector';
+import { useSpaceFilter } from './useSpaceFilter';
+
+interface UseSpaceSelectorOptions {
+  isDisabled?: boolean;
+  documentationUrl?: string;
+  onSpaceChange?: (spaceId: string) => void;
+}
+
+export const useSpaceSelector = (options: UseSpaceSelectorOptions = {}) => {
+  const { isDisabled, documentationUrl, onSpaceChange } = options;
+  const [spaceFilter, setSpaceFilter] = useSpaceFilter();
+
+  const handleSpaceChange = useCallback(
+    (id: string) => {
+      setSpaceFilter(id);
+      onSpaceChange?.(id);
+    },
+    [setSpaceFilter, onSpaceChange]
+  );
+
+  const component = (
+    <SpaceSelector
+      selectedSpace={spaceFilter}
+      onSpaceChange={handleSpaceChange}
+      isDisabled={isDisabled}
+      documentationUrl={documentationUrl}
+    />
+  );
+
+  return { component, spaceFilter };
+};

--- a/public/pages/Decoders/containers/Decoders.tsx
+++ b/public/pages/Decoders/containers/Decoders.tsx
@@ -36,7 +36,7 @@ import {
 import { buildDecodersSearchQuery } from '../utils/constants';
 import { DecoderDetailsFlyout } from '../components/DecoderDetailsFlyout';
 import { SpaceTypes } from '../../../../common/constants';
-import { SpaceSelector } from '../../../components/SpaceSelector';
+import { useSpaceSelector } from '../../../hooks/useSpaceSelector';
 
 const DEFAULT_PAGE_SIZE = 25;
 const SORT_FIELD_MAP: Record<string, string> = {
@@ -62,8 +62,9 @@ export const Decoders: React.FC<DecodersProps> = ({ history, notifications }) =>
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [sortField, setSortField] = useState<string>('document.name');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
-  const [spaceFilter, setSpaceFilter] = useState<string>(SpaceTypes.STANDARD.value);
-  const [spacesLoading, setSpacesLoading] = useState(false);
+  const { component: spaceSelector, spaceFilter } = useSpaceSelector({
+    onSpaceChange: () => setPageIndex(0),
+  });
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [selectedDecoder, setSelectedDecoder] = useState<{
     id: string;
@@ -252,17 +253,6 @@ export const Decoders: React.FC<DecodersProps> = ({ history, notifications }) =>
       },
     ],
     [spaceFilter, deleteDecoder]
-  );
-
-  const spaceSelector = (
-    <SpaceSelector
-      selectedSpace={spaceFilter}
-      onSpaceChange={(id) => {
-        setSpaceFilter(id);
-        setPageIndex(0);
-      }}
-      isDisabled={spacesLoading}
-    />
   );
 
   const panels = [

--- a/public/pages/Integrations/components/IntegrationDetails.tsx
+++ b/public/pages/Integrations/components/IntegrationDetails.tsx
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { EuiSmallButton, EuiDescriptionList } from "@elastic/eui";
-import { ContentPanel } from "../../../components/ContentPanel";
-import React from "react";
-import { IntegrationItem } from "../../../../types";
-import { DataStore } from "../../../store/DataStore";
-import { IntegrationForm } from "./IntegrationForm";
-import { NotificationsStart } from "opensearch-dashboards/public";
-import { successNotificationToast } from "../../../utils/helpers";
+import { EuiSmallButton, EuiDescriptionList } from '@elastic/eui';
+import { ContentPanel } from '../../../components/ContentPanel';
+import React from 'react';
+import { IntegrationItem } from '../../../../types';
+import { DataStore } from '../../../store/DataStore';
+import { IntegrationForm } from './IntegrationForm';
+import { NotificationsStart } from 'opensearch-dashboards/public';
+import { successNotificationToast } from '../../../utils/helpers';
 
 export interface IntegrationDetailsProps {
   initialIntegrationDetails: IntegrationItem;
@@ -34,13 +34,13 @@ export const IntegrationDetails: React.FC<IntegrationDetailsProps> = ({
   const onUpdateIntegration = async () => {
     const success = await DataStore.integrations.updateIntegration(
       integrationId,
-      integrationDetails,
+      integrationDetails
     );
     if (success) {
       successNotificationToast(
         notifications,
-        "updated",
-        `integration ${integrationDetails.document.title}`,
+        'updated',
+        `integration ${integrationDetails.document.title}`
       );
       setIsEditMode(false);
     }
@@ -51,23 +51,19 @@ export const IntegrationDetails: React.FC<IntegrationDetailsProps> = ({
       title="Details"
       actions={
         !isEditMode &&
-        integrationDetails.space.name.toLocaleLowerCase() !== "standard" && [
-          <EuiSmallButton onClick={() => setIsEditMode(true)}>
-            Edit
-          </EuiSmallButton>,
+        integrationDetails.space.name.toLocaleLowerCase() !== 'standard' && [
+          <EuiSmallButton onClick={() => setIsEditMode(true)}>Edit</EuiSmallButton>,
         ]
       }
     >
       <EuiDescriptionList
-        type="column"
         listItems={[
           {
-            title: "Integration", // Replace Log type to Integration by Wazuh
             description: (
               <IntegrationForm
                 integrationDetails={integrationDetails}
                 isEditMode={isEditMode}
-                confirmButtonText={"Update"}
+                confirmButtonText={'Update'}
                 notifications={notifications}
                 setIntegrationDetails={setIntegrationDetails}
                 onCancel={() => {

--- a/public/pages/Integrations/components/PolicyInfo.tsx
+++ b/public/pages/Integrations/components/PolicyInfo.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { withGuardAsync } from '../utils/helpers';
 import { DataStore } from '../../../store/DataStore';
-import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
+  EuiDescriptionList,
+} from '@elastic/eui';
 import { DecoderSource, PolicyDocument, Space } from '../../../../types';
 import { ButtonSelectRootDecoder } from './RootDecoderRequirement';
 import { NotificationsStart } from 'opensearch-dashboards/public';
@@ -49,22 +56,36 @@ export const PolicyInfoCard: React.FC<{}> = withPolicyGuard(
     check;
   }) => {
     return (
-      <EuiPanel paddingSize="s">
-        <EuiTitle size="s">
-          <h3>Space info</h3>
-        </EuiTitle>
-        <EuiSpacer size="s" />
-        <EuiFlexGroup>
-          <EuiFlexItem>Title: {policyDocumentData.title}</EuiFlexItem>
-          <EuiFlexItem>Description: {policyDocumentData.description}</EuiFlexItem>
-          <EuiFlexItem>Author: {policyDocumentData.author}</EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiFlexGroup alignItems="center">
-          <EuiFlexItem>Documentation: {policyDocumentData.documentation}</EuiFlexItem>
-          <EuiFlexItem>References: {policyDocumentData.references.join(', ')}</EuiFlexItem>
-          <EuiFlexItem>
-            <div style={{ display: 'flex', alignItems: 'center', flexGrow: 0 }}>
-              <div style={{ flexGrow: 0 }}>Root decoder: {rootDecoder?.document?.name ?? ''}</div>
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <EuiDescriptionList compressed type="row">
+            <EuiDescriptionListTitle>Title</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {policyDocumentData.title}
+            </EuiDescriptionListDescription>
+            <EuiDescriptionListTitle>Description</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {policyDocumentData.description}
+            </EuiDescriptionListDescription>
+            <EuiDescriptionListTitle>Author</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {policyDocumentData.author}
+            </EuiDescriptionListDescription>
+          </EuiDescriptionList>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiDescriptionList compressed type="row">
+            <EuiDescriptionListTitle>Documentation</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {policyDocumentData.documentation}
+            </EuiDescriptionListDescription>
+            <EuiDescriptionListTitle>References</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {policyDocumentData.references.join(', ')}
+            </EuiDescriptionListDescription>
+            <EuiDescriptionListTitle>Root decoder</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {rootDecoder?.document?.name ?? ''}
               {actionIsAllowedOnSpace(space, SPACE_ACTIONS.DEFINE_ROOT_DECODER) && (
                 <ButtonSelectRootDecoder
                   notifications={notifications}
@@ -76,10 +97,10 @@ export const PolicyInfoCard: React.FC<{}> = withPolicyGuard(
                   onConfirm={check}
                 ></ButtonSelectRootDecoder>
               )}
-            </div>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPanel>
+            </EuiDescriptionListDescription>
+          </EuiDescriptionList>
+        </EuiFlexItem>
+      </EuiFlexGroup>
     );
   }
 );

--- a/public/pages/Integrations/containers/Integration.tsx
+++ b/public/pages/Integrations/containers/Integration.tsx
@@ -103,8 +103,12 @@ export const Integration: React.FC<IntegrationProps> = ({ notifications, history
       setBreadcrumbs([BREADCRUMBS.INTEGRATIONS, { text: details.document.title }]);
       const integrationItem = {
         ...details,
-        detectionRulesCount: details.detectionRules.length,
+        detectionRulesCount: details.detectionRules.length ?? 0,
+        decodersCount: details.document.decoders?.length ?? 0,
+        kvdbsCount: details.document.kvdbs?.length ?? 0,
       };
+      setIntegrationDetails(integrationItem);
+      setInitialIntegrationDetails(integrationItem);
       updateRules(integrationItem, integrationItem);
     };
 
@@ -236,6 +240,26 @@ export const Integration: React.FC<IntegrationProps> = ({ notifications, history
                 {
                   title: 'Detection rules',
                   description: integrationDetails.detectionRulesCount,
+                },
+              ]}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiDescriptionList
+              listItems={[
+                {
+                  title: 'Decoders',
+                  description: integrationDetails.decodersCount,
+                },
+              ]}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiDescriptionList
+              listItems={[
+                {
+                  title: 'KVDBs',
+                  description: integrationDetails.kvdbsCount,
                 },
               ]}
             />

--- a/public/pages/Integrations/containers/Integrations.tsx
+++ b/public/pages/Integrations/containers/Integrations.tsx
@@ -26,10 +26,10 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import { setBreadcrumbs, successNotificationToast } from '../../../utils/helpers';
 import { DeleteIntegrationModal } from '../components/DeleteIntegrationModal';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
-import { SpaceSelector } from '../../../components/SpaceSelector/SpaceSelector';
 import { AllowedActionsBySpace, SPACE_ACTIONS, SpaceTypes } from '../../../../common/constants';
 import { RootDecoderRequirement } from '../components/RootDecoderRequirement';
 import { PolicyInfoCard } from '../components/PolicyInfo';
+import { useSpaceSelector } from '../../../hooks/useSpaceSelector';
 
 export interface IntegrationsProps extends RouteComponentProps, DataSourceProps {
   notifications: NotificationsStart;
@@ -43,7 +43,7 @@ export const Integrations: React.FC<IntegrationsProps> = ({
 }) => {
   const isMountedRef = useRef(true);
   const [integrations, setIntegrations] = useState<Integration[]>([]);
-  const [spaceFilter, setSpaceFilter] = useState<string>(SpaceTypes.STANDARD.value);
+  const { component: spaceSelector, spaceFilter } = useSpaceSelector();
   const [loading, setLoading] = useState<boolean>(false);
   const [selectedItems, setSelectedItems] = useState<Integration[]>([]);
   const [itemForAction, setItemForAction] = useState<{
@@ -72,15 +72,6 @@ export const Integrations: React.FC<IntegrationsProps> = ({
   }, []);
 
   setBreadcrumbs([BREADCRUMBS.INTEGRATIONS]);
-
-  const spaceSelector = (
-    <SpaceSelector
-      selectedSpace={spaceFilter}
-      onSpaceChange={(id) => {
-        setSpaceFilter(id);
-      }}
-    />
-  );
 
   const isCreateActionDisabled = !AllowedActionsBySpace[
     SpaceTypes[spaceFilter.toUpperCase()].value
@@ -208,6 +199,8 @@ export const Integrations: React.FC<IntegrationsProps> = ({
                 Integrations describe the data sources to which the detection rules are meant to be
                 applied.
               </EuiText>
+              <EuiSpacer size="s"></EuiSpacer>
+              <PolicyInfoCard space={spaceFilter} notifications={notifications} />
             </EuiFlexItem>
             {/* <EuiFlexItem grow={false}>{createIntegrationAction}</EuiFlexItem> */}
             <EuiFlexItem grow={false}>{spaceSelector}</EuiFlexItem>
@@ -217,8 +210,6 @@ export const Integrations: React.FC<IntegrationsProps> = ({
         </EuiFlexItem>
       </PageHeader>
       <EuiPanel>
-        <PolicyInfoCard space={spaceFilter} notifications={notifications} />
-        <EuiSpacer size="s"></EuiSpacer>
         <EuiInMemoryTable
           itemId={'id'}
           items={integrations}

--- a/public/pages/Integrations/utils/helpers.tsx
+++ b/public/pages/Integrations/utils/helpers.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../../common/constants';
 import { capitalize, startCase } from 'lodash';
 import { Search } from '@opensearch-project/oui/src/eui_components/basic_table';
-import { DEFAULT_EMPTY_DATA, integrationCategories } from '../../../utils/constants';
+import { DEFAULT_EMPTY_DATA, integrationCategoryFilters } from '../../../utils/constants';
 import { integrationLabels } from './constants';
 
 export const getIntegrationsTableColumns = ({
@@ -106,7 +106,7 @@ export const getIntegrationsTableSearchConfig = (): Search => {
         name: 'Category',
         compressed: true,
         multiSelect: 'or',
-        options: integrationCategories.map((category) => ({
+        options: integrationCategoryFilters.map((category) => ({
           value: category,
         })),
       },

--- a/public/pages/KVDBs/containers/KVDBs.tsx
+++ b/public/pages/KVDBs/containers/KVDBs.tsx
@@ -1,9 +1,9 @@
 /*
  * Copyright Wazuh Inc.
  * SPDX-License-Identifier: AGPL-3.0-or-later
-*/
+ */
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   EuiBasicTable,
   EuiBasicTableColumn,
@@ -16,21 +16,17 @@ import {
   EuiSpacer,
   EuiText,
   EuiToolTip,
-} from "@elastic/eui";
-import { RouteComponentProps } from "react-router-dom";
-import { KVDBItem } from "../../../../types";
-import { DataStore } from "../../../store/DataStore";
-import { BREADCRUMBS, DEFAULT_EMPTY_DATA } from "../../../utils/constants";
-import { PageHeader } from "../../../components/PageHeader/PageHeader";
-import { formatCellValue, setBreadcrumbs } from "../../../utils/helpers";
-import {
-  KVDBS_PAGE_SIZE,
-  KVDBS_SEARCH_SCHEMA,
-  KVDBS_SORT_FIELD,
-} from "../utils/constants";
-import { KVDBDetailsFlyout } from "../components/KVDBDetailsFlyout";
-import { SpaceTypes } from "../../../../common/constants";
-import { SpaceSelector } from "../../../components/SpaceSelector/SpaceSelector";
+} from '@elastic/eui';
+import { RouteComponentProps } from 'react-router-dom';
+import { KVDBItem } from '../../../../types';
+import { DataStore } from '../../../store/DataStore';
+import { BREADCRUMBS, DEFAULT_EMPTY_DATA } from '../../../utils/constants';
+import { PageHeader } from '../../../components/PageHeader/PageHeader';
+import { formatCellValue, setBreadcrumbs } from '../../../utils/helpers';
+import { KVDBS_PAGE_SIZE, KVDBS_SEARCH_SCHEMA, KVDBS_SORT_FIELD } from '../utils/constants';
+import { KVDBDetailsFlyout } from '../components/KVDBDetailsFlyout';
+import { SpaceTypes } from '../../../../common/constants';
+import { useSpaceSelector } from '../../../hooks/useSpaceSelector';
 
 export const KVDBs: React.FC<RouteComponentProps> = () => {
   const [items, setItems] = useState<KVDBItem[]>([]);
@@ -39,11 +35,13 @@ export const KVDBs: React.FC<RouteComponentProps> = () => {
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(KVDBS_PAGE_SIZE);
   const [sortField, setSortField] = useState(KVDBS_SORT_FIELD);
-  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [searchQuery, setSearchQuery] = useState<any>(null);
   const [refreshTick, setRefreshTick] = useState(0);
   const [selectedKVDB, setSelectedKVDB] = useState<KVDBItem | null>(null);
-  const [spaceFilter, setSpaceFilter] = useState<string>(SpaceTypes.STANDARD.value);
+  const { component: spaceSelector, spaceFilter } = useSpaceSelector({
+    onSpaceChange: () => setPageIndex(0),
+  });
   const [actionsPopoverOpen, setActionsPopoverOpen] = useState<boolean>(false);
 
   useEffect(() => {
@@ -51,9 +49,7 @@ export const KVDBs: React.FC<RouteComponentProps> = () => {
   }, []);
 
   const buildQuery = useCallback(() => {
-    let query = searchQuery
-      ? EuiSearchBar.Query.toESQuery(searchQuery)
-      : { match_all: {} };
+    let query = searchQuery ? EuiSearchBar.Query.toESQuery(searchQuery) : { match_all: {} };
     if (!query || Object.keys(query).length === 0) {
       query = { match_all: {} };
     }
@@ -62,7 +58,7 @@ export const KVDBs: React.FC<RouteComponentProps> = () => {
     if (spaceFilter) {
       query = {
         bool: {
-          must: [query, { term: { "space.name": spaceFilter } }],
+          must: [query, { term: { 'space.name': spaceFilter } }],
         },
       };
     }
@@ -110,7 +106,7 @@ export const KVDBs: React.FC<RouteComponentProps> = () => {
 
     if (sort) {
       setSortField(sort.field || KVDBS_SORT_FIELD);
-      setSortDirection(sort.direction || "asc");
+      setSortDirection(sort.direction || 'asc');
     }
   };
 
@@ -126,7 +122,7 @@ export const KVDBs: React.FC<RouteComponentProps> = () => {
       totalItemCount,
       pageSizeOptions: [10, 25, 50, 100],
     }),
-    [pageIndex, pageSize, totalItemCount],
+    [pageIndex, pageSize, totalItemCount]
   );
 
   const sorting = useMemo(
@@ -136,22 +132,22 @@ export const KVDBs: React.FC<RouteComponentProps> = () => {
         direction: sortDirection,
       },
     }),
-    [sortField, sortDirection],
+    [sortField, sortDirection]
   );
 
   const columns: Array<EuiBasicTableColumn<KVDBItem>> = useMemo(
     () => [
       {
-        field: "document.title",
-        name: "Title",
+        field: 'document.title',
+        name: 'Title',
         sortable: true,
-        dataType: "string",
+        dataType: 'string',
         render: (value: string) => formatCellValue(value),
       },
       {
-        field: "integration.title",
-        name: "Integration",
-        dataType: "string",
+        field: 'integration.title',
+        name: 'Integration',
+        dataType: 'string',
         render: (value: string) => formatCellValue(value),
       },
       {
@@ -161,8 +157,8 @@ export const KVDBs: React.FC<RouteComponentProps> = () => {
         render: (value: string) => formatCellValue(value),
       },
       {
-        name: "Actions",
-        align: "right",
+        name: 'Actions',
+        align: 'right',
         render: (item: KVDBItem) => (
           <EuiToolTip content="View details">
             <EuiButtonIcon
@@ -174,40 +170,26 @@ export const KVDBs: React.FC<RouteComponentProps> = () => {
         ),
       },
     ],
-    [],
+    []
   );
 
   return (
     <EuiFlexGroup direction="column" gutterSize="m">
       {selectedKVDB && (
-        <KVDBDetailsFlyout
-          kvdb={selectedKVDB}
-          onClose={() => setSelectedKVDB(null)}
-        />
+        <KVDBDetailsFlyout kvdb={selectedKVDB} onClose={() => setSelectedKVDB(null)} />
       )}
       <EuiFlexItem grow={false}>
-      <PageHeader>
-        <EuiFlexGroup
-          gutterSize="s"
-          justifyContent="spaceBetween"
-          alignItems="center"
-        >
-          <EuiFlexItem>
-            <EuiText size="s">
-              <h1>KVDBs</h1>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <SpaceSelector
-              selectedSpace={spaceFilter}
-              onSpaceChange={(id) => {
-                setSpaceFilter(id);
-                setPageIndex(0);
-              }}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </PageHeader></EuiFlexItem>
+        <PageHeader>
+          <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween" alignItems="center">
+            <EuiFlexItem>
+              <EuiText size="s">
+                <h1>KVDBs</h1>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>{spaceSelector}</EuiFlexItem>
+          </EuiFlexGroup>
+        </PageHeader>
+      </EuiFlexItem>
       <EuiSpacer size="xs" />
       <EuiFlexItem>
         <EuiPanel>
@@ -215,7 +197,7 @@ export const KVDBs: React.FC<RouteComponentProps> = () => {
             <EuiFlexItem>
               <EuiSearchBar
                 box={{
-                  placeholder: "Search KVDBs",
+                  placeholder: 'Search KVDBs',
                   incremental: true,
                   compressed: true,
                   schema: true,
@@ -225,10 +207,7 @@ export const KVDBs: React.FC<RouteComponentProps> = () => {
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiSmallButton
-                iconType="refresh"
-                onClick={() => setRefreshTick((t) => t + 1)}
-              >
+              <EuiSmallButton iconType="refresh" onClick={() => setRefreshTick((t) => t + 1)}>
                 Refresh
               </EuiSmallButton>
             </EuiFlexItem>

--- a/public/store/IntegrationStore.ts
+++ b/public/store/IntegrationStore.ts
@@ -19,7 +19,7 @@ import { DataStore } from './DataStore';
 import { ruleTypes } from '../pages/Rules/utils/constants';
 import {
   DATA_SOURCE_NOT_SET_ERROR,
-  integrationCategories,
+  integrationCategoryFilters,
   integrationsByCategories,
 } from '../utils/constants';
 import { getIntegrationLabel } from '../pages/Integrations/utils/helpers';
@@ -91,9 +91,9 @@ export class IntegrationStore {
             integrationsByCategories[integration.category] || [];
           integrationsByCategories[integration.category].push(integration);
         });
-        integrationCategories.splice(
+        integrationCategoryFilters.splice(
           0,
-          integrationCategories.length,
+          integrationCategoryFilters.length,
           ...Object.keys(integrationsByCategories).sort((a, b) => {
             if (a === 'Other') {
               return 1;

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -273,9 +273,7 @@ export const ALERT_STATE = Object.freeze({
 export const logTypesWithDashboards = new Set(['network', 'cloudtrail', 's3']);
 
 export const pendingDashboardCreations: {
-  [detectorId: string]:
-    | undefined
-    | Promise<void | ServerResponse<SimpleSavedObject<unknown>>>;
+  [detectorId: string]: undefined | Promise<void | ServerResponse<SimpleSavedObject<unknown>>>;
 } = {};
 
 export const logTypeCategoryDescription: {
@@ -344,11 +342,10 @@ export const integrationCategories: {
     description: 'Logs not covered in other categories',
   },
 ];
-export const integrationCategoryFilters: string[] = integrationCategories.map(
-  ({ value }) => value
-); 
 
 export const integrationsByCategories: { [category: string]: Integration[] } = {};
+
+export const integrationCategoryFilters: string[] = integrationCategories.map(({ value }) => value);
 
 export const logTypeCategories: string[] = [];
 export const logTypesByCategories: { [category: string]: LogType[] } = {};

--- a/types/Integrations.ts
+++ b/types/Integrations.ts
@@ -11,6 +11,8 @@ export interface IntegrationWithRules extends Integration {
 
 export interface IntegrationItem extends Integration {
   detectionRulesCount: number;
+  decodersCount: number;
+  kvdbsCount: number;
 }
 
 export interface Integration extends Omit<IntegrationBase, 'document'> {


### PR DESCRIPTION
### Description

This PR adds create buttons to the integration sub-tabs to allow users to create related resources directly from the integration view.

## Changes

- Added **Create decoder** button to the Decoders tab.
- Added **Create kvdb** button to the KVDBs tab.
(Buttons follow the same design pattern used in Detection rules).
- Note: The kvdb creation feature is not included in this PR. I have left comments indicating where it should be implemented in future updates.

## Issues resolved
Issue: [#61 ](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/61)

## Evidence

<img width="1854" height="963" alt="Captura desde 2026-02-18 12-08-37" src="https://github.com/user-attachments/assets/f724ef4b-7000-473f-b6b4-02cd32ab83d3" />

## Tests

- Go to Security Analytics > Integrations > Draft.
- Click on any Integration to test this feature.
- Verify that the "Create" buttons appear correctly on all sub-tabs.
- Verify that the "Create" buttons work correctly on the Detection Rules and Decoders sub-tabs.


### Check List
- [x] Update CHANGELOG.md
- [x] Commits are signed per the DCO using --signoff