### PR TITLE
Remove duplicated space label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to the Wazuh ML Commons project will be documented in this f
 - Hide Alerts/Correlations and Correlation rules from the Security Analytics navigation, leaving Findings at the root level [#8004](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8004)
 - Changed the management of rules [#96](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/96) [#125](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/125) [#165](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/165)
 - Renamed Dectection rules to rules [#96](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/96)
-- Updated Detectors management feature [#111](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/111) [#134](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/134) [#159](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/159)
+- Updated Detectors management feature [#111](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/111) [#134](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/134) [#159](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/159) [#173](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/173)
 - Rules table and details now display the real integration title. [#164](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/164)
 
 ### Removed

--- a/public/components/SpaceSelector/SpaceSelector.tsx
+++ b/public/components/SpaceSelector/SpaceSelector.tsx
@@ -43,7 +43,7 @@ export const SpaceSelector: React.FC<SpaceSelectorProps> = ({
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiText size="s" style={{ whiteSpace: "nowrap" }}>
+        <EuiText size="s" style={{ whiteSpace: "nowrap", fontWeight: 500 }}>
           {SPACE_SELECTOR_LABEL}
         </EuiText>
       </EuiFlexItem>

--- a/public/pages/Detectors/components/WazuhUpdateBasicDetails/WazuhUpdateBasicDetails.tsx
+++ b/public/pages/Detectors/components/WazuhUpdateBasicDetails/WazuhUpdateBasicDetails.tsx
@@ -443,11 +443,6 @@ export const WazuhUpdateDetectorBasicDetails: React.FC<WazuhUpdateDetectorBasicD
 
         <EuiFlexGroup alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiText size="s">
-              <strong>Space</strong>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
             <SpaceSelector
               selectedSpace={selectedSpace}
               onSpaceChange={onSpaceChange}

--- a/public/pages/WazuhCreateDetector/components/DefineDetector/components/DetectorType/DetectorType.tsx
+++ b/public/pages/WazuhCreateDetector/components/DefineDetector/components/DetectorType/DetectorType.tsx
@@ -116,11 +116,6 @@ export default class DetectorType extends Component<DetectorTypeProps, DetectorT
 
         <EuiFlexGroup alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiText size="s">
-              <strong>Space</strong>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
             <SpaceSelector
               selectedSpace={selectedSpace}
               onSpaceChange={this.onSpaceChange}


### PR DESCRIPTION
### Description
This pull request removes the duplicated Space label from the Decoders create and edit forms.

### Issues Resolved
#172 

<img width="1589" height="1755" alt="image" src="https://github.com/user-attachments/assets/ba9cd648-8b68-43c8-9d40-f22f986759bc" />



### Check List
- [x] Commits are signed per the DCO using --signoff
