### PR TITLE
The space does not appear on the detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to the Wazuh ML Commons project will be documented in this f
 - Hide Alerts/Correlations and Correlation rules from the Security Analytics navigation, leaving Findings at the root level [#8004](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8004)
 - Changed the management of rules [#96](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/96) [#125](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/125) [#165](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/165)
 - Renamed Dectection rules to rules [#96](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/96)
-- Updated Detectors management feature [#111](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/111) [#134](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/134) [#159](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/159) [#173](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/173)
+- Updated Detectors management feature [#111](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/111) [#134](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/134) [#159](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/159) [#173](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/173) [#181](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/181)
 - Rules table and details now display the real integration title. [#164](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/164)
 - Updated nav menu group label to "Security analytics" to match Wazuh Dashboard capitalization style. [#178](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/178)
 

--- a/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
+++ b/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
@@ -252,7 +252,7 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
       )?.id;
 
       if (ruleForMapping) {
-        const rules = await DataStore.rules.getAllRules({ _id: [ruleForMapping] });
+        const rules = await DataStore.rules.getAllRules({ 'document.id': [ruleForMapping] });
 
         const spaceRule = rules?.find?.((rule) => rule._id === ruleForMapping);
 
@@ -260,7 +260,10 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
           standard: 'Standard',
           custom: 'Custom',
         };
-        return mapper[spaceRule?.space];
+        // Fallback: if the rule is not found with rules datastore, infer space from the detector structure itself.
+        return (
+          mapper[spaceRule?.space] ?? (custom_rules.length > 0 ? mapper.custom : mapper.standard)
+        );
       }
     } catch {}
   }

--- a/public/pages/Detectors/containers/Detectors/Detectors.tsx
+++ b/public/pages/Detectors/containers/Detectors/Detectors.tsx
@@ -104,7 +104,7 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
           .filter(Boolean);
 
         const uniqueRuleIds = Array.from(new Set(detectorRuleForSpaceMapping));
-        const rules = await DataStore.rules.getAllRules({ _id: uniqueRuleIds });
+        const rules = await DataStore.rules.getAllRules({ 'document.id': uniqueRuleIds });
 
         const detectors = res.response.hits.hits.map((detector, index) => {
           const { custom_rules, pre_packaged_rules } = detector._source.inputs[0].detector_input;
@@ -120,7 +120,9 @@ export default class Detectors extends Component<DetectorsProps, DetectorsState>
             custom: 'Custom',
           };
 
-          const space = mapper[spaceRule?.space];
+          // Fallback: if the rule is not found, infer space from the detector structure itself.
+          const space =
+            mapper[spaceRule?.space] ?? (custom_rules.length > 0 ? mapper.custom : mapper.standard);
 
           return {
             ...detector,

--- a/public/store/WazuhRulesStore.ts
+++ b/public/store/WazuhRulesStore.ts
@@ -108,6 +108,12 @@ export class RulesStore implements IWazuhRulesStore {
     let query: object;
     if (terms?.['_id']) {
       query = { ids: { values: terms['_id'] } };
+    } else if (terms?.['document.id']) {
+      query = {
+        terms: {
+          'document.id': terms['document.id'],
+        },
+      };
     } else if (terms?.['rule.category']) {
       const categories = terms['rule.category'].map((c) => c.toLowerCase());
       query = {


### PR DESCRIPTION
### Description

- Query to get rules in detectors to infer space was wrongfully using `_id` instead of `document.id` which caused to get no custom rule matches.
- Added fallback to infer space just by detector structure in case rules request fails.
- Update rules datastore to allow querying by document.id.

### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/180

### Evidence

<img width="2522" height="1410" alt="image" src="https://github.com/user-attachments/assets/c97e7b15-385b-411b-a6e0-7a78316d6b8d" />

<img width="2556" height="1462" alt="image" src="https://github.com/user-attachments/assets/7bf386ff-3dbc-4a35-a9a6-e9d10aa7b6fa" />


### Test
- Check `Space` is visible in both Detectors table and Detector details.

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).