### PR TITLE
Add detection support to Log Test page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Wazuh ML Commons project will be documented in this f
 - Added Log test feature [#43](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/43) [#97](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/97) [#131](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/131) [#176](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/176)
 - Added Filters management feature [#108](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/108) [#137](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/137)
 - Added clear space action to the Overview actions button [#186](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/186)
+- Added detection support to Log Test page [#191](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/191)
 
 ### Changed
 

--- a/public/pages/LogTest/components/LogTestForm.tsx
+++ b/public/pages/LogTest/components/LogTestForm.tsx
@@ -28,6 +28,8 @@ const TRACE_LEVEL_OPTIONS: Array<{ value: LogTestTraceLevel; text: string }> = [
 export interface LogTestSpaceOption {
   id: string;
   label: string;
+  disabled?: boolean;
+  title?: string;
 }
 
 export interface LogTestIntegrationOption {
@@ -72,7 +74,12 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
   disabled = false,
 }) => {
   const spaceSelectOptions = [
-    ...spaceOptions.map((option) => ({ value: option.id, text: option.label })),
+    ...spaceOptions.map((option) => ({
+      value: option.id,
+      text: option.label,
+      disabled: option.disabled,
+      title: option.title,
+    })),
   ];
 
   const integrationSelectOptions = [
@@ -85,18 +92,13 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
 
   return (
     <>
-      <EuiTitle size='xs'>
+      <EuiTitle size="xs">
         <h3>Normalization</h3>
       </EuiTitle>
-      <EuiSpacer size='s' />
-      <EuiFlexGroup gutterSize='m' wrap>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup gutterSize="m" wrap>
         <EuiFlexItem style={{ minWidth: '280px' }}>
-          <EuiFormRow
-            label='Space'
-            isInvalid={!!errors.space}
-            error={errors.space}
-            fullWidth
-          >
+          <EuiFormRow label="Space" isInvalid={!!errors.space} error={errors.space} fullWidth>
             <EuiSelect
               options={spaceSelectOptions}
               value={formData.space}
@@ -120,33 +122,31 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
             <EuiFieldText
               value={formData.location}
               onChange={(e) => onFormChange('location', e.target.value)}
-              placeholder='/var/log/auth.log'
+              placeholder="/var/log/auth.log"
               disabled={disabled}
               fullWidth
             />
           </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem style={{ minWidth: '200px' }}>
-          <EuiFormRow label='Trace level' fullWidth>
+          <EuiFormRow label="Trace level" fullWidth>
             <EuiSelect
               options={TRACE_LEVEL_OPTIONS}
               value={formData.traceLevel}
-              onChange={(e) =>
-                onFormChange('traceLevel', e.target.value as LogTestTraceLevel)
-              }
+              onChange={(e) => onFormChange('traceLevel', e.target.value as LogTestTraceLevel)}
               disabled={disabled}
               fullWidth
             />
           </EuiFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer size='m' />
+      <EuiSpacer size="m" />
       <EuiAccordion
-        id='agent-metadata-accordion'
-        buttonContent='Metadata (optional)'
-        paddingSize='m'
+        id="agent-metadata-accordion"
+        buttonContent="Metadata (optional)"
+        paddingSize="m"
       >
-        <EuiSpacer size='s' />
+        <EuiSpacer size="s" />
         <MetadataFieldsEditor
           entries={formData.metadataFields}
           onChange={onMetadataFieldsChange}
@@ -154,13 +154,13 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
         />
       </EuiAccordion>
 
-      <EuiSpacer size='l' />
+      <EuiSpacer size="l" />
 
-      <EuiTitle size='xs'>
+      <EuiTitle size="xs">
         <h3>Detection</h3>
       </EuiTitle>
-      <EuiSpacer size='s' />
-      <EuiFlexGroup gutterSize='m'>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup gutterSize="m">
         <EuiFlexItem style={{ minWidth: '300px' }}>
           <EuiFormRow
             label={
@@ -182,16 +182,11 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
         </EuiFlexItem>
       </EuiFlexGroup>
 
-      <EuiSpacer size='l' />
+      <EuiSpacer size="l" />
 
-      <EuiFormRow
-        label='Log event'
-        isInvalid={!!errors.event}
-        error={errors.event}
-        fullWidth
-      >
+      <EuiFormRow label="Log event" isInvalid={!!errors.event} error={errors.event} fullWidth>
         <EuiTextArea
-          placeholder='Enter log data to test...'
+          placeholder="Enter log data to test..."
           value={formData.event}
           onChange={(e) => onFormChange('event', e.target.value)}
           rows={6}

--- a/public/pages/LogTest/components/LogTestForm.tsx
+++ b/public/pages/LogTest/components/LogTestForm.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from "react";
+import React from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -14,15 +14,15 @@ import {
   EuiSpacer,
   EuiSelect,
   EuiTitle,
-} from "@elastic/eui";
-import { LogTestTraceLevel } from "../../../../types";
-import { MetadataEntry } from "../utils";
-import { MetadataFieldsEditor } from "./MetadataFieldsEditor";
+} from '@elastic/eui';
+import { LogTestTraceLevel } from '../../../../types';
+import { MetadataEntry } from '../utils';
+import { MetadataFieldsEditor } from './MetadataFieldsEditor';
 
 const TRACE_LEVEL_OPTIONS: Array<{ value: LogTestTraceLevel; text: string }> = [
-  { value: "NONE", text: "None" },
-  { value: "ASSET_ONLY", text: "Asset only" },
-  { value: "ALL", text: "All" },
+  { value: 'NONE', text: 'None' },
+  { value: 'ASSET_ONLY', text: 'Asset only' },
+  { value: 'ALL', text: 'All' },
 ];
 
 export interface LogTestSpaceOption {
@@ -76,7 +76,7 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
   ];
 
   const integrationSelectOptions = [
-    { value: "", text: "Select an integration" },
+    { value: '', text: 'Select an integration' },
     ...integrationOptions.map((option) => ({
       value: option.id,
       text: option.label,
@@ -85,14 +85,14 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
 
   return (
     <>
-      <EuiTitle size="xs">
+      <EuiTitle size='xs'>
         <h3>Normalization</h3>
       </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiFlexGroup gutterSize="m" wrap>
-        <EuiFlexItem style={{ minWidth: "280px" }}>
+      <EuiSpacer size='s' />
+      <EuiFlexGroup gutterSize='m' wrap>
+        <EuiFlexItem style={{ minWidth: '280px' }}>
           <EuiFormRow
-            label="Space"
+            label='Space'
             isInvalid={!!errors.space}
             error={errors.space}
             fullWidth
@@ -100,18 +100,18 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
             <EuiSelect
               options={spaceSelectOptions}
               value={formData.space}
-              onChange={(e) => onFormChange("space", e.target.value)}
+              onChange={(e) => onFormChange('space', e.target.value)}
               isInvalid={!!errors.space}
               disabled={disabled || spaceSelectOptions.length === 0}
               fullWidth
             />
           </EuiFormRow>
         </EuiFlexItem>
-        <EuiFlexItem style={{ minWidth: "300px" }}>
+        <EuiFlexItem style={{ minWidth: '300px' }}>
           <EuiFormRow
             label={
               <>
-                {"Location - "}
+                {'Location - '}
                 <em>optional</em>
               </>
             }
@@ -119,20 +119,20 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
           >
             <EuiFieldText
               value={formData.location}
-              onChange={(e) => onFormChange("location", e.target.value)}
-              placeholder="/var/log/auth.log"
+              onChange={(e) => onFormChange('location', e.target.value)}
+              placeholder='/var/log/auth.log'
               disabled={disabled}
               fullWidth
             />
           </EuiFormRow>
         </EuiFlexItem>
-        <EuiFlexItem style={{ minWidth: "200px" }}>
-          <EuiFormRow label="Trace level" fullWidth>
+        <EuiFlexItem style={{ minWidth: '200px' }}>
+          <EuiFormRow label='Trace level' fullWidth>
             <EuiSelect
               options={TRACE_LEVEL_OPTIONS}
               value={formData.traceLevel}
               onChange={(e) =>
-                onFormChange("traceLevel", e.target.value as LogTestTraceLevel)
+                onFormChange('traceLevel', e.target.value as LogTestTraceLevel)
               }
               disabled={disabled}
               fullWidth
@@ -140,13 +140,13 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
           </EuiFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer size="m" />
+      <EuiSpacer size='m' />
       <EuiAccordion
-        id="agent-metadata-accordion"
-        buttonContent="Metadata (optional)"
-        paddingSize="m"
+        id='agent-metadata-accordion'
+        buttonContent='Metadata (optional)'
+        paddingSize='m'
       >
-        <EuiSpacer size="s" />
+        <EuiSpacer size='s' />
         <MetadataFieldsEditor
           entries={formData.metadataFields}
           onChange={onMetadataFieldsChange}
@@ -154,18 +154,18 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
         />
       </EuiAccordion>
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size='l' />
 
-      <EuiTitle size="xs">
+      <EuiTitle size='xs'>
         <h3>Detection</h3>
       </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiFlexGroup gutterSize="m">
-        <EuiFlexItem style={{ minWidth: "300px" }}>
+      <EuiSpacer size='s' />
+      <EuiFlexGroup gutterSize='m'>
+        <EuiFlexItem style={{ minWidth: '300px' }}>
           <EuiFormRow
             label={
               <>
-                {"Integration - "}
+                {'Integration - '}
                 <em>optional</em>
               </>
             }
@@ -174,7 +174,7 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
             <EuiSelect
               options={integrationSelectOptions}
               value={formData.integration}
-              onChange={(e) => onFormChange("integration", e.target.value)}
+              onChange={(e) => onFormChange('integration', e.target.value)}
               disabled={disabled || integrationSelectOptions.length <= 1}
               fullWidth
             />
@@ -182,18 +182,18 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
         </EuiFlexItem>
       </EuiFlexGroup>
 
-      <EuiSpacer size="l" />
+      <EuiSpacer size='l' />
 
       <EuiFormRow
-        label="Log event"
+        label='Log event'
         isInvalid={!!errors.event}
         error={errors.event}
         fullWidth
       >
         <EuiTextArea
-          placeholder="Enter log data to test..."
+          placeholder='Enter log data to test...'
           value={formData.event}
-          onChange={(e) => onFormChange("event", e.target.value)}
+          onChange={(e) => onFormChange('event', e.target.value)}
           rows={6}
           isInvalid={!!errors.event}
           disabled={disabled}

--- a/public/pages/LogTest/components/LogTestForm.tsx
+++ b/public/pages/LogTest/components/LogTestForm.tsx
@@ -3,29 +3,34 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
+import React from "react";
 import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
   EuiFieldText,
-  EuiFieldNumber,
   EuiTextArea,
   EuiAccordion,
   EuiSpacer,
   EuiSelect,
-} from '@elastic/eui';
-import { LogTestTraceLevel } from '../../../../types';
-import { MetadataEntry } from '../utils';
-import { MetadataFieldsEditor } from './MetadataFieldsEditor';
+  EuiTitle,
+} from "@elastic/eui";
+import { LogTestTraceLevel } from "../../../../types";
+import { MetadataEntry } from "../utils";
+import { MetadataFieldsEditor } from "./MetadataFieldsEditor";
 
 const TRACE_LEVEL_OPTIONS: Array<{ value: LogTestTraceLevel; text: string }> = [
-  { value: 'NONE', text: 'None' },
-  { value: 'ASSET_ONLY', text: 'Asset only' },
-  { value: 'ALL', text: 'All' },
+  { value: "NONE", text: "None" },
+  { value: "ASSET_ONLY", text: "Asset only" },
+  { value: "ALL", text: "All" },
 ];
 
 export interface LogTestSpaceOption {
+  id: string;
+  label: string;
+}
+
+export interface LogTestIntegrationOption {
   id: string;
   label: string;
 }
@@ -37,12 +42,14 @@ export interface LogTestFormData {
   traceLevel: LogTestTraceLevel;
   space: string;
   metadataFields: MetadataEntry[];
+  integration: string;
 }
 
 export interface LogTestFormErrors {
   queue?: string;
   event?: string;
   space?: string;
+  integration?: string;
 }
 
 export interface LogTestFormProps {
@@ -51,6 +58,7 @@ export interface LogTestFormProps {
   onFormChange: (field: keyof LogTestFormData, value: any) => void;
   onMetadataFieldsChange: (fields: MetadataEntry[]) => void;
   spaceOptions: LogTestSpaceOption[];
+  integrationOptions: LogTestIntegrationOption[];
   disabled?: boolean;
 }
 
@@ -60,75 +68,72 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
   onFormChange,
   onMetadataFieldsChange,
   spaceOptions,
+  integrationOptions,
   disabled = false,
 }) => {
   const spaceSelectOptions = [
     ...spaceOptions.map((option) => ({ value: option.id, text: option.label })),
   ];
 
+  const integrationSelectOptions = [
+    { value: "", text: "Select an integration" },
+    ...integrationOptions.map((option) => ({
+      value: option.id,
+      text: option.label,
+    })),
+  ];
+
   return (
     <>
+      <EuiTitle size="xs">
+        <h3>Normalization</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
       <EuiFlexGroup gutterSize="m" wrap>
-        {/* <EuiFlexItem style={{ minWidth: '300px' }}>
-                    <EuiFormRow
-                        label="Queue"
-                        isInvalid={!!errors.queue}
-                        error={errors.queue}
-                        fullWidth
-                    >
-                        <EuiFieldNumber
-                            value={formData.queue ?? ''}
-                            onChange={(e) =>
-                                onFormChange(
-                                    'queue',
-                                    e.target.value ? Number(e.target.value) : undefined
-                                )
-                            }
-                            min={1}
-                            max={255}
-                            isInvalid={!!errors.queue}
-                            disabled={disabled}
-                            fullWidth
-                        />
-                    </EuiFormRow>
-                </EuiFlexItem> */}
-        <EuiFlexItem style={{ minWidth: '280px' }}>
-          <EuiFormRow label="Space" isInvalid={!!errors.space} error={errors.space} fullWidth>
+        <EuiFlexItem style={{ minWidth: "280px" }}>
+          <EuiFormRow
+            label="Space"
+            isInvalid={!!errors.space}
+            error={errors.space}
+            fullWidth
+          >
             <EuiSelect
               options={spaceSelectOptions}
               value={formData.space}
-              onChange={(e) => onFormChange('space', e.target.value)}
+              onChange={(e) => onFormChange("space", e.target.value)}
               isInvalid={!!errors.space}
               disabled={disabled || spaceSelectOptions.length === 0}
               fullWidth
             />
           </EuiFormRow>
         </EuiFlexItem>
-        <EuiFlexItem style={{ minWidth: '300px' }}>
-          <EuiFormRow 
-          label={
-            <>
-              {'Location - '}
-              <em>optional</em>
-            </>
-           } 
+        <EuiFlexItem style={{ minWidth: "300px" }}>
+          <EuiFormRow
+            label={
+              <>
+                {"Location - "}
+                <em>optional</em>
+              </>
+            }
             fullWidth
           >
             <EuiFieldText
               value={formData.location}
-              onChange={(e) => onFormChange('location', e.target.value)}
+              onChange={(e) => onFormChange("location", e.target.value)}
               placeholder="/var/log/auth.log"
               disabled={disabled}
               fullWidth
             />
           </EuiFormRow>
         </EuiFlexItem>
-        <EuiFlexItem style={{ minWidth: '200px' }}>
+        <EuiFlexItem style={{ minWidth: "200px" }}>
           <EuiFormRow label="Trace level" fullWidth>
             <EuiSelect
               options={TRACE_LEVEL_OPTIONS}
               value={formData.traceLevel}
-              onChange={(e) => onFormChange('traceLevel', e.target.value as LogTestTraceLevel)}
+              onChange={(e) =>
+                onFormChange("traceLevel", e.target.value as LogTestTraceLevel)
+              }
               disabled={disabled}
               fullWidth
             />
@@ -148,12 +153,47 @@ export const LogTestForm: React.FC<LogTestFormProps> = ({
           disabled={disabled}
         />
       </EuiAccordion>
-      <EuiSpacer size="m" />
-      <EuiFormRow label="Log event" isInvalid={!!errors.event} error={errors.event} fullWidth>
+
+      <EuiSpacer size="l" />
+
+      <EuiTitle size="xs">
+        <h3>Detection</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup gutterSize="m">
+        <EuiFlexItem style={{ minWidth: "300px" }}>
+          <EuiFormRow
+            label={
+              <>
+                {"Integration - "}
+                <em>optional</em>
+              </>
+            }
+            fullWidth
+          >
+            <EuiSelect
+              options={integrationSelectOptions}
+              value={formData.integration}
+              onChange={(e) => onFormChange("integration", e.target.value)}
+              disabled={disabled || integrationSelectOptions.length <= 1}
+              fullWidth
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="l" />
+
+      <EuiFormRow
+        label="Log event"
+        isInvalid={!!errors.event}
+        error={errors.event}
+        fullWidth
+      >
         <EuiTextArea
           placeholder="Enter log data to test..."
           value={formData.event}
-          onChange={(e) => onFormChange('event', e.target.value)}
+          onChange={(e) => onFormChange("event", e.target.value)}
           rows={6}
           isInvalid={!!errors.event}
           disabled={disabled}

--- a/public/pages/LogTest/components/LogTestResult.tsx
+++ b/public/pages/LogTest/components/LogTestResult.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from "react";
 import {
   EuiText,
   EuiCodeBlock,
@@ -14,14 +14,17 @@ import {
   EuiFlexItem,
   EuiPanel,
   EuiCallOut,
-} from '@elastic/eui';
+  EuiTabs,
+  EuiTab,
+} from "@elastic/eui";
 import {
   LogTestResponse,
   LogTestAssetTrace,
-  LogTestMatchedRule,
-  LogTestResult as LogTestResultType,
+  LogTestNormalizationResult,
+  LogTestDetectionResult,
+  LogTestDetectionRuleMatch,
   LogTestValidationError,
-} from '../../../../types';
+} from "../../../../types";
 
 export interface LogTestResultProps {
   result: LogTestResponse;
@@ -37,8 +40,8 @@ const AssetTraceItem: React.FC<{ trace: LogTestAssetTrace; index: number }> = ({
       buttonContent={
         <EuiFlexGroup alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiBadge color={trace.success ? 'success' : 'danger'}>
-              {trace.success ? 'Success' : 'Failed'}
+            <EuiBadge color={trace.success ? "success" : "danger"}>
+              {trace.success ? "Success" : "Failed"}
             </EuiBadge>
           </EuiFlexItem>
           <EuiFlexItem>
@@ -52,7 +55,7 @@ const AssetTraceItem: React.FC<{ trace: LogTestAssetTrace; index: number }> = ({
     >
       {trace.traces && trace.traces.length > 0 ? (
         <EuiCodeBlock language="text" paddingSize="s" fontSize="s" isCopyable>
-          {trace.traces.join('\n')}
+          {trace.traces.join("\n")}
         </EuiCodeBlock>
       ) : (
         <EuiText size="s" color="subdued">
@@ -63,46 +66,14 @@ const AssetTraceItem: React.FC<{ trace: LogTestAssetTrace; index: number }> = ({
   );
 };
 
-const MatchedRuleItem: React.FC<{ rule: LogTestMatchedRule; index: number }> = ({
-  rule,
-  index,
-}) => {
-  const ruleId = rule.id ?? rule.rule_id ?? '';
-  const ruleName = rule.title ?? rule.name ?? ruleId ?? `Rule ${index + 1}`;
-  const level = rule.level ?? rule.severity ?? '';
-
-  return (
-    <EuiAccordion
-      id={`matched-rule-${index}`}
-      buttonContent={
-        <EuiFlexGroup alignItems="center" gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiBadge color="hollow">{level || 'Level not available'}</EuiBadge>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText size="s">
-              <strong>{ruleName}</strong>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      }
-      paddingSize="s"
-    >
-      <EuiCodeBlock language="json" paddingSize="s" fontSize="s" isCopyable overflowHeight={220}>
-        {JSON.stringify(rule, null, 2)}
-      </EuiCodeBlock>
-    </EuiAccordion>
-  );
-};
-
-const ValidationErrorItem: React.FC<{ error: LogTestValidationError; index: number }> = ({
-  error,
-  index,
-}) => {
+const ValidationErrorItem: React.FC<{
+  error: LogTestValidationError;
+  index: number;
+}> = ({ error, index }) => {
   const listItems = Object.entries(error)
     .filter(([, value]) => value != null)
     .map(([key, value]) => ({
-      title: <span style={{ textTransform: 'capitalize' }}>{key}</span>,
+      title: <span style={{ textTransform: "capitalize" }}>{key}</span>,
       description: String(value),
     }));
 
@@ -111,18 +82,31 @@ const ValidationErrorItem: React.FC<{ error: LogTestValidationError; index: numb
       id={`validation-error-${index}`}
       initialIsOpen={false}
       buttonContent={
-         <EuiText size="s">
-           <code>{error.path}</code>
-         </EuiText>
+        <EuiText size="s">
+          <code>{error.path}</code>
+        </EuiText>
       }
       paddingSize="none"
     >
-      <div style={{ padding: '8px 12px 4px' }}>
-        <EuiPanel color="subdued" paddingSize="s" hasShadow={false} hasBorder={false}>
-          <div style={{ display: 'grid', gridTemplateColumns: '200px 1fr', rowGap: 8 }}>
+      <div style={{ padding: "8px 12px 4px" }}>
+        <EuiPanel
+          color="subdued"
+          paddingSize="s"
+          hasShadow={false}
+          hasBorder={false}
+        >
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "200px 1fr",
+              rowGap: 8,
+            }}
+          >
             {listItems.map(({ title, description }, i) => (
               <React.Fragment key={i}>
-                <EuiText size="s"><strong>{title}</strong></EuiText>
+                <EuiText size="s">
+                  <strong>{title}</strong>
+                </EuiText>
                 <EuiText size="s">{description}</EuiText>
               </React.Fragment>
             ))}
@@ -133,53 +117,102 @@ const ValidationErrorItem: React.FC<{ error: LogTestValidationError; index: numb
   );
 };
 
-export const LogTestResult: React.FC<LogTestResultProps> = ({ result }) => {
-  const parsedMessage: LogTestResultType = useMemo(() => {
-    if (!result?.message) return null;
-    try {
-      const parsed = result.message;
-      const output = parsed.output;
-      return { ...parsed, output };
-    } catch {
-      return null;
-    }
-  }, [result?.message]);
+function getLevelBadgeColor(level: string): string {
+  switch (level.toLowerCase()) {
+    case "critical":
+      return "danger";
+    case "high":
+      return "danger";
+    case "medium":
+      return "warning";
+    case "low":
+      return "default";
+    default:
+      return "hollow";
+  }
+}
 
+const DetectionMatchItem: React.FC<{
+  match: LogTestDetectionRuleMatch;
+  index: number;
+}> = ({ match, index }) => {
+  const { rule, matched_conditions } = match;
+
+  return (
+    <EuiAccordion
+      id={`detection-match-${index}`}
+      buttonContent={
+        <EuiFlexGroup alignItems="center" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiBadge color={getLevelBadgeColor(rule.level)}>
+              {rule.level}
+            </EuiBadge>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size="s">
+              <strong>{rule.title}</strong>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      }
+      paddingSize="s"
+    >
+      {rule.tags && rule.tags.length > 0 && (
+        <>
+          <EuiFlexGroup gutterSize="xs" wrap>
+            {rule.tags.map((tag) => (
+              <EuiFlexItem grow={false} key={tag}>
+                <EuiBadge color="hollow">{tag}</EuiBadge>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+          <EuiSpacer size="s" />
+        </>
+      )}
+      {matched_conditions && matched_conditions.length > 0 && (
+        <>
+          <EuiText size="xs" color="subdued">
+            <strong>Matched conditions:</strong>
+          </EuiText>
+          <EuiSpacer size="xs" />
+          <ul style={{ margin: 0, paddingLeft: 20 }}>
+            {matched_conditions.map((condition, i) => (
+              <li key={i}>
+                <EuiText size="s">
+                  <code>{condition}</code>
+                </EuiText>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </EuiAccordion>
+  );
+};
+
+const NormalizationSection: React.FC<{ data: LogTestNormalizationResult }> = ({
+  data,
+}) => {
   const formattedOutput = useMemo(() => {
-    if (parsedMessage?.output) {
-      return JSON.stringify(parsedMessage.output, null, 2);
+    if (data?.output) {
+      return JSON.stringify(data.output, null, 2);
     }
     return null;
-  }, [parsedMessage?.output]);
+  }, [data?.output]);
 
-  const hasAssetTraces = parsedMessage?.asset_traces?.length > 0;
-  const hasMatchedRules = parsedMessage?.matched_rules?.length > 0;
-  const hasValidation = parsedMessage?.validation != null;
+  const hasAssetTraces = data?.asset_traces && data.asset_traces.length > 0;
+  const hasValidation = data?.validation != null;
 
   return (
     <>
-      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiText size="s">
-            <h3>Test Result</h3>
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup alignItems="center" gutterSize="m">
-            <EuiFlexItem grow={false}>
-              <EuiBadge color={result?.status === 'OK' ? 'success' : 'warning'}>
-                {result?.status}
-              </EuiBadge>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-
-      <EuiSpacer size="m" />
-
       {formattedOutput ? (
         <EuiPanel paddingSize="none">
-          <EuiCodeBlock language="json" paddingSize="m" isCopyable overflowHeight={400}>
+          <EuiCodeBlock
+            language="json"
+            paddingSize="m"
+            isCopyable
+            overflowHeight={400}
+          >
             {formattedOutput}
           </EuiCodeBlock>
         </EuiPanel>
@@ -204,7 +237,7 @@ export const LogTestResult: React.FC<LogTestResultProps> = ({ result }) => {
           >
             <EuiSpacer size="s" />
             <EuiPanel paddingSize="m">
-              {parsedMessage.asset_traces!.map((trace, index) => (
+              {data.asset_traces!.map((trace, index) => (
                 <React.Fragment key={`${trace.asset}-${index}`}>
                   {index > 0 && <EuiSpacer size="s" />}
                   <AssetTraceItem trace={trace} index={index} />
@@ -215,25 +248,7 @@ export const LogTestResult: React.FC<LogTestResultProps> = ({ result }) => {
         </>
       )}
 
-      {hasMatchedRules && (
-        <>
-          <EuiSpacer size="l" />
-          <EuiText size="s">
-            <h4>Matched Rules</h4>
-          </EuiText>
-          <EuiSpacer size="s" />
-          <EuiPanel paddingSize="m">
-            {parsedMessage.matched_rules!.map((rule, index) => (
-              <React.Fragment key={`${rule.id ?? rule.rule_id ?? 'rule'}-${index}`}>
-                {index > 0 && <EuiSpacer size="s" />}
-                <MatchedRuleItem rule={rule} index={index} />
-              </React.Fragment>
-            ))}
-          </EuiPanel>
-        </>
-      )}
-
-      {hasValidation && !parsedMessage.validation!.valid && (
+      {hasValidation && !data.validation!.valid && (
         <>
           <EuiSpacer size="l" />
           <EuiAccordion
@@ -253,12 +268,14 @@ export const LogTestResult: React.FC<LogTestResultProps> = ({ result }) => {
             }
             paddingSize="s"
           >
-            {parsedMessage.validation!.errors.length > 0 && (
+            {data.validation!.errors.length > 0 && (
               <>
                 <EuiSpacer size="s" />
                 <EuiPanel paddingSize="m">
-                  {parsedMessage.validation!.errors.map((error, index) => (
-                    <React.Fragment key={`${error.path}-${error.kind}-${index}`}>
+                  {data.validation!.errors.map((error, index) => (
+                    <React.Fragment
+                      key={`${error.path}-${error.kind}-${index}`}
+                    >
                       {index > 0 && <EuiSpacer size="s" />}
                       <ValidationErrorItem error={error} index={index} />
                     </React.Fragment>
@@ -269,6 +286,128 @@ export const LogTestResult: React.FC<LogTestResultProps> = ({ result }) => {
           </EuiAccordion>
         </>
       )}
+    </>
+  );
+};
+
+const DetectionSection: React.FC<{ data: LogTestDetectionResult }> = ({
+  data,
+}) => {
+  if (data.status === "skipped") {
+    return (
+      <EuiCallOut title="Detection skipped" color="warning" iconType="alert">
+        <p>{data.reason || "Detection was skipped."}</p>
+      </EuiCallOut>
+    );
+  }
+
+  const matches = data.matches ?? [];
+
+  if (matches.length === 0) {
+    return (
+      <EuiCallOut title="No rules matched" color="primary" iconType="iInCircle">
+        <p>
+          {data.rules_evaluated != null
+            ? `${data.rules_evaluated} rules evaluated, 0 matched.`
+            : "No detection rules matched the log event."}
+        </p>
+      </EuiCallOut>
+    );
+  }
+
+  return (
+    <>
+      <EuiText size="s">
+        <p>
+          <strong>{data.rules_evaluated}</strong> rules evaluated,{" "}
+          <strong>{data.rules_matched}</strong> matched
+        </p>
+      </EuiText>
+      <EuiSpacer size="m" />
+      <EuiPanel paddingSize="m">
+        {matches.map((match, index) => (
+          <React.Fragment key={`${match.rule.id}-${index}`}>
+            {index > 0 && <EuiSpacer size="s" />}
+            <DetectionMatchItem match={match} index={index} />
+          </React.Fragment>
+        ))}
+      </EuiPanel>
+    </>
+  );
+};
+
+type ResultTab = "normalization" | "detection";
+
+export const LogTestResult: React.FC<LogTestResultProps> = ({ result }) => {
+  const [selectedTab, setSelectedTab] = useState<ResultTab>("normalization");
+  const normalization = result?.message?.normalization;
+  const detection = result?.message?.detection;
+
+  return (
+    <>
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiText size="s">
+            <h3>Test Result</h3>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiBadge
+            color={
+              result?.status === "OK" || String(result?.status) === "200"
+                ? "success"
+                : "warning"
+            }
+          >
+            {result?.status}
+          </EuiBadge>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="m" />
+
+      <EuiTabs size="s">
+        <EuiTab
+          isSelected={selectedTab === "normalization"}
+          onClick={() => setSelectedTab("normalization")}
+        >
+          Normalization
+        </EuiTab>
+        <EuiTab
+          isSelected={selectedTab === "detection"}
+          onClick={() => setSelectedTab("detection")}
+        >
+          Detection
+        </EuiTab>
+      </EuiTabs>
+
+      <EuiSpacer size="m" />
+
+      {selectedTab === "normalization" &&
+        (normalization ? (
+          <NormalizationSection data={normalization} />
+        ) : (
+          <EuiCallOut
+            title="No normalization data"
+            color="primary"
+            iconType="iInCircle"
+          >
+            <p>The logtest did not return normalization results.</p>
+          </EuiCallOut>
+        ))}
+
+      {selectedTab === "detection" &&
+        (detection ? (
+          <DetectionSection data={detection} />
+        ) : (
+          <EuiCallOut
+            title="No detection data"
+            color="primary"
+            iconType="iInCircle"
+          >
+            <p>The logtest did not return detection results.</p>
+          </EuiCallOut>
+        ))}
     </>
   );
 };

--- a/public/pages/LogTest/components/LogTestResult.tsx
+++ b/public/pages/LogTest/components/LogTestResult.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState } from 'react';
 import {
   EuiText,
   EuiCodeBlock,
@@ -16,7 +16,7 @@ import {
   EuiCallOut,
   EuiTabs,
   EuiTab,
-} from "@elastic/eui";
+} from '@elastic/eui';
 import {
   LogTestResponse,
   LogTestAssetTrace,
@@ -24,7 +24,7 @@ import {
   LogTestDetectionResult,
   LogTestDetectionRuleMatch,
   LogTestValidationError,
-} from "../../../../types";
+} from '../../../../types';
 
 export interface LogTestResultProps {
   result: LogTestResponse;
@@ -38,27 +38,27 @@ const AssetTraceItem: React.FC<{ trace: LogTestAssetTrace; index: number }> = ({
     <EuiAccordion
       id={`asset-trace-${index}`}
       buttonContent={
-        <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexGroup alignItems='center' gutterSize='s'>
           <EuiFlexItem grow={false}>
-            <EuiBadge color={trace.success ? "success" : "danger"}>
-              {trace.success ? "Success" : "Failed"}
+            <EuiBadge color={trace.success ? 'success' : 'danger'}>
+              {trace.success ? 'Success' : 'Failed'}
             </EuiBadge>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText size="s">
+            <EuiText size='s'>
               <code>{trace.asset}</code>
             </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
       }
-      paddingSize="s"
+      paddingSize='s'
     >
       {trace.traces && trace.traces.length > 0 ? (
-        <EuiCodeBlock language="text" paddingSize="s" fontSize="s" isCopyable>
-          {trace.traces.join("\n")}
+        <EuiCodeBlock language='text' paddingSize='s' fontSize='s' isCopyable>
+          {trace.traces.join('\n')}
         </EuiCodeBlock>
       ) : (
-        <EuiText size="s" color="subdued">
+        <EuiText size='s' color='subdued'>
           No trace details available
         </EuiText>
       )}
@@ -73,7 +73,7 @@ const ValidationErrorItem: React.FC<{
   const listItems = Object.entries(error)
     .filter(([, value]) => value != null)
     .map(([key, value]) => ({
-      title: <span style={{ textTransform: "capitalize" }}>{key}</span>,
+      title: <span style={{ textTransform: 'capitalize' }}>{key}</span>,
       description: String(value),
     }));
 
@@ -82,32 +82,32 @@ const ValidationErrorItem: React.FC<{
       id={`validation-error-${index}`}
       initialIsOpen={false}
       buttonContent={
-        <EuiText size="s">
+        <EuiText size='s'>
           <code>{error.path}</code>
         </EuiText>
       }
-      paddingSize="none"
+      paddingSize='none'
     >
-      <div style={{ padding: "8px 12px 4px" }}>
+      <div style={{ padding: '8px 12px 4px' }}>
         <EuiPanel
-          color="subdued"
-          paddingSize="s"
+          color='subdued'
+          paddingSize='s'
           hasShadow={false}
           hasBorder={false}
         >
           <div
             style={{
-              display: "grid",
-              gridTemplateColumns: "200px 1fr",
+              display: 'grid',
+              gridTemplateColumns: '200px 1fr',
               rowGap: 8,
             }}
           >
             {listItems.map(({ title, description }, i) => (
               <React.Fragment key={i}>
-                <EuiText size="s">
+                <EuiText size='s'>
                   <strong>{title}</strong>
                 </EuiText>
-                <EuiText size="s">{description}</EuiText>
+                <EuiText size='s'>{description}</EuiText>
               </React.Fragment>
             ))}
           </div>
@@ -119,16 +119,16 @@ const ValidationErrorItem: React.FC<{
 
 function getLevelBadgeColor(level: string): string {
   switch (level.toLowerCase()) {
-    case "critical":
-      return "danger";
-    case "high":
-      return "danger";
-    case "medium":
-      return "warning";
-    case "low":
-      return "default";
+    case 'critical':
+      return 'danger';
+    case 'high':
+      return 'danger';
+    case 'medium':
+      return 'warning';
+    case 'low':
+      return 'default';
     default:
-      return "hollow";
+      return 'hollow';
   }
 }
 
@@ -142,43 +142,43 @@ const DetectionMatchItem: React.FC<{
     <EuiAccordion
       id={`detection-match-${index}`}
       buttonContent={
-        <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexGroup alignItems='center' gutterSize='s'>
           <EuiFlexItem grow={false}>
             <EuiBadge color={getLevelBadgeColor(rule.level)}>
               {rule.level}
             </EuiBadge>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText size="s">
+            <EuiText size='s'>
               <strong>{rule.title}</strong>
             </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
       }
-      paddingSize="s"
+      paddingSize='s'
     >
       {rule.tags && rule.tags.length > 0 && (
         <>
-          <EuiFlexGroup gutterSize="xs" wrap>
+          <EuiFlexGroup gutterSize='xs' wrap>
             {rule.tags.map((tag) => (
               <EuiFlexItem grow={false} key={tag}>
-                <EuiBadge color="hollow">{tag}</EuiBadge>
+                <EuiBadge color='hollow'>{tag}</EuiBadge>
               </EuiFlexItem>
             ))}
           </EuiFlexGroup>
-          <EuiSpacer size="s" />
+          <EuiSpacer size='s' />
         </>
       )}
       {matched_conditions && matched_conditions.length > 0 && (
         <>
-          <EuiText size="xs" color="subdued">
+          <EuiText size='xs' color='subdued'>
             <strong>Matched conditions:</strong>
           </EuiText>
-          <EuiSpacer size="xs" />
+          <EuiSpacer size='xs' />
           <ul style={{ margin: 0, paddingLeft: 20 }}>
             {matched_conditions.map((condition, i) => (
               <li key={i}>
-                <EuiText size="s">
+                <EuiText size='s'>
                   <code>{condition}</code>
                 </EuiText>
               </li>
@@ -206,10 +206,10 @@ const NormalizationSection: React.FC<{ data: LogTestNormalizationResult }> = ({
   return (
     <>
       {formattedOutput ? (
-        <EuiPanel paddingSize="none">
+        <EuiPanel paddingSize='none'>
           <EuiCodeBlock
-            language="json"
-            paddingSize="m"
+            language='json'
+            paddingSize='m'
             isCopyable
             overflowHeight={400}
           >
@@ -217,29 +217,29 @@ const NormalizationSection: React.FC<{ data: LogTestNormalizationResult }> = ({
           </EuiCodeBlock>
         </EuiPanel>
       ) : (
-        <EuiCallOut title="No output" color="warning" iconType="alert">
+        <EuiCallOut title='No output' color='warning' iconType='alert'>
           <p>The logtest did not return any output.</p>
         </EuiCallOut>
       )}
 
       {hasAssetTraces && (
         <>
-          <EuiSpacer size="l" />
+          <EuiSpacer size='l' />
           <EuiAccordion
-            id="asset-traces-section"
+            id='asset-traces-section'
             initialIsOpen={false}
             buttonContent={
-              <EuiText size="s">
+              <EuiText size='s'>
                 <h4>Asset Traces</h4>
               </EuiText>
             }
-            paddingSize="s"
+            paddingSize='s'
           >
-            <EuiSpacer size="s" />
-            <EuiPanel paddingSize="m">
+            <EuiSpacer size='s' />
+            <EuiPanel paddingSize='m'>
               {data.asset_traces!.map((trace, index) => (
                 <React.Fragment key={`${trace.asset}-${index}`}>
-                  {index > 0 && <EuiSpacer size="s" />}
+                  {index > 0 && <EuiSpacer size='s' />}
                   <AssetTraceItem trace={trace} index={index} />
                 </React.Fragment>
               ))}
@@ -250,33 +250,33 @@ const NormalizationSection: React.FC<{ data: LogTestNormalizationResult }> = ({
 
       {hasValidation && !data.validation!.valid && (
         <>
-          <EuiSpacer size="l" />
+          <EuiSpacer size='l' />
           <EuiAccordion
-            id="validation-section"
+            id='validation-section'
             initialIsOpen
             buttonContent={
-              <EuiFlexGroup alignItems="center" gutterSize="s">
+              <EuiFlexGroup alignItems='center' gutterSize='s'>
                 <EuiFlexItem>
-                  <EuiText size="s">
+                  <EuiText size='s'>
                     <h4>Validation</h4>
                   </EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiBadge color="danger">Failed</EuiBadge>
+                  <EuiBadge color='danger'>Failed</EuiBadge>
                 </EuiFlexItem>
               </EuiFlexGroup>
             }
-            paddingSize="s"
+            paddingSize='s'
           >
             {data.validation!.errors.length > 0 && (
               <>
-                <EuiSpacer size="s" />
-                <EuiPanel paddingSize="m">
+                <EuiSpacer size='s' />
+                <EuiPanel paddingSize='m'>
                   {data.validation!.errors.map((error, index) => (
                     <React.Fragment
                       key={`${error.path}-${error.kind}-${index}`}
                     >
-                      {index > 0 && <EuiSpacer size="s" />}
+                      {index > 0 && <EuiSpacer size='s' />}
                       <ValidationErrorItem error={error} index={index} />
                     </React.Fragment>
                   ))}
@@ -293,18 +293,18 @@ const NormalizationSection: React.FC<{ data: LogTestNormalizationResult }> = ({
 const DetectionSection: React.FC<{ data: LogTestDetectionResult }> = ({
   data,
 }) => {
-  if (data.status === "skipped") {
+  if (data.status === 'skipped') {
     return (
-      <EuiCallOut title="Detection skipped" color="warning" iconType="alert">
-        <p>{data.reason || "Detection was skipped."}</p>
+      <EuiCallOut title='Detection skipped' color='warning' iconType='alert'>
+        <p>{data.reason || 'Detection was skipped.'}</p>
       </EuiCallOut>
     );
   }
 
-  if (data.status === "error") {
+  if (data.status === 'error') {
     return (
-      <EuiCallOut title="Detection error" color="danger" iconType="alert">
-        <p>{data.reason || "Detection failed due to an unexpected error."}</p>
+      <EuiCallOut title='Detection error' color='danger' iconType='alert'>
+        <p>{data.reason || 'Detection failed due to an unexpected error.'}</p>
       </EuiCallOut>
     );
   }
@@ -313,11 +313,11 @@ const DetectionSection: React.FC<{ data: LogTestDetectionResult }> = ({
 
   if (matches.length === 0) {
     return (
-      <EuiCallOut title="No rules matched" color="primary" iconType="iInCircle">
+      <EuiCallOut title='No rules matched' color='primary' iconType='iInCircle'>
         <p>
           {data.rules_evaluated != null
             ? `${data.rules_evaluated} rules evaluated, 0 matched.`
-            : "No detection rules matched the log event."}
+            : 'No detection rules matched the log event.'}
         </p>
       </EuiCallOut>
     );
@@ -325,17 +325,17 @@ const DetectionSection: React.FC<{ data: LogTestDetectionResult }> = ({
 
   return (
     <>
-      <EuiText size="s">
+      <EuiText size='s'>
         <p>
-          <strong>{data.rules_evaluated}</strong> rules evaluated,{" "}
+          <strong>{data.rules_evaluated}</strong> rules evaluated,{' '}
           <strong>{data.rules_matched}</strong> matched
         </p>
       </EuiText>
-      <EuiSpacer size="m" />
-      <EuiPanel paddingSize="m">
+      <EuiSpacer size='m' />
+      <EuiPanel paddingSize='m'>
         {matches.map((match, index) => (
           <React.Fragment key={`${match.rule.id}-${index}`}>
-            {index > 0 && <EuiSpacer size="s" />}
+            {index > 0 && <EuiSpacer size='s' />}
             <DetectionMatchItem match={match} index={index} />
           </React.Fragment>
         ))}
@@ -344,27 +344,27 @@ const DetectionSection: React.FC<{ data: LogTestDetectionResult }> = ({
   );
 };
 
-type ResultTab = "normalization" | "detection";
+type ResultTab = 'normalization' | 'detection';
 
 export const LogTestResult: React.FC<LogTestResultProps> = ({ result }) => {
-  const [selectedTab, setSelectedTab] = useState<ResultTab>("normalization");
+  const [selectedTab, setSelectedTab] = useState<ResultTab>('normalization');
   const normalization = result?.message?.normalization;
   const detection = result?.message?.detection;
 
   return (
     <>
-      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+      <EuiFlexGroup justifyContent='spaceBetween' alignItems='center'>
         <EuiFlexItem grow={false}>
-          <EuiText size="s">
+          <EuiText size='s'>
             <h3>Test Result</h3>
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiBadge
             color={
-              result?.status === "OK" || String(result?.status) === "200"
-                ? "success"
-                : "warning"
+              result?.status === 'OK' || String(result?.status) === '200'
+                ? 'success'
+                : 'warning'
             }
           >
             {result?.status}
@@ -372,46 +372,46 @@ export const LogTestResult: React.FC<LogTestResultProps> = ({ result }) => {
         </EuiFlexItem>
       </EuiFlexGroup>
 
-      <EuiSpacer size="m" />
+      <EuiSpacer size='m' />
 
-      <EuiTabs size="s">
+      <EuiTabs size='s'>
         <EuiTab
-          isSelected={selectedTab === "normalization"}
-          onClick={() => setSelectedTab("normalization")}
+          isSelected={selectedTab === 'normalization'}
+          onClick={() => setSelectedTab('normalization')}
         >
           Normalization
         </EuiTab>
         <EuiTab
-          isSelected={selectedTab === "detection"}
-          onClick={() => setSelectedTab("detection")}
+          isSelected={selectedTab === 'detection'}
+          onClick={() => setSelectedTab('detection')}
         >
           Detection
         </EuiTab>
       </EuiTabs>
 
-      <EuiSpacer size="m" />
+      <EuiSpacer size='m' />
 
-      {selectedTab === "normalization" &&
+      {selectedTab === 'normalization' &&
         (normalization ? (
           <NormalizationSection data={normalization} />
         ) : (
           <EuiCallOut
-            title="No normalization data"
-            color="primary"
-            iconType="iInCircle"
+            title='No normalization data'
+            color='primary'
+            iconType='iInCircle'
           >
             <p>The logtest did not return normalization results.</p>
           </EuiCallOut>
         ))}
 
-      {selectedTab === "detection" &&
+      {selectedTab === 'detection' &&
         (detection ? (
           <DetectionSection data={detection} />
         ) : (
           <EuiCallOut
-            title="No detection data"
-            color="primary"
-            iconType="iInCircle"
+            title='No detection data'
+            color='primary'
+            iconType='iInCircle'
           >
             <p>The logtest did not return detection results.</p>
           </EuiCallOut>

--- a/public/pages/LogTest/components/LogTestResult.tsx
+++ b/public/pages/LogTest/components/LogTestResult.tsx
@@ -301,6 +301,14 @@ const DetectionSection: React.FC<{ data: LogTestDetectionResult }> = ({
     );
   }
 
+  if (data.status === "error") {
+    return (
+      <EuiCallOut title="Detection error" color="danger" iconType="alert">
+        <p>{data.reason || "Detection failed due to an unexpected error."}</p>
+      </EuiCallOut>
+    );
+  }
+
   const matches = data.matches ?? [];
 
   if (matches.length === 0) {

--- a/public/pages/LogTest/containers/LogTest.tsx
+++ b/public/pages/LogTest/containers/LogTest.tsx
@@ -70,7 +70,7 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
     setBreadcrumbs([BREADCRUMBS.LOG_TEST]);
   }, []);
 
-  const refreshSpaceCache = useCallback(async (): Promise<SpaceCache> => {
+  const loadSpaceCache = useCallback(async (): Promise<SpaceCache> => {
     const entries = await Promise.all(
       INITIAL_SPACE_OPTIONS.map((option) =>
         DataStore.policies
@@ -115,7 +115,7 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
   }, [notifications]);
 
   useEffect(() => {
-    refreshSpaceCache();
+    loadSpaceCache();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/public/pages/LogTest/containers/LogTest.tsx
+++ b/public/pages/LogTest/containers/LogTest.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from "react";
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -12,30 +12,33 @@ import {
   EuiText,
   EuiButton,
   EuiHorizontalRule,
-} from '@elastic/eui';
-import { RouteComponentProps } from 'react-router-dom';
-import { PageHeader } from '../../../components/PageHeader/PageHeader';
-import { setBreadcrumbs } from '../../../utils/helpers';
-import { BREADCRUMBS } from '../../../utils/constants';
-import { DataStore } from '../../../store/DataStore';
-import { SpaceTypes } from '../../../../common/constants';
-import { LogTestResponse } from '../../../../types';
+} from "@elastic/eui";
+import { RouteComponentProps } from "react-router-dom";
+import { NotificationsStart } from "opensearch-dashboards/public";
+import { PageHeader } from "../../../components/PageHeader/PageHeader";
+import { errorNotificationToast, setBreadcrumbs } from "../../../utils/helpers";
+import { BREADCRUMBS } from "../../../utils/constants";
+import { DataStore } from "../../../store/DataStore";
+import { SpaceTypes } from "../../../../common/constants";
+import { LogTestResponse } from "../../../../types";
 import {
   LogTestForm,
   LogTestFormData,
   LogTestFormErrors,
   LogTestSpaceOption,
-} from '../components/LogTestForm';
-import { LogTestResult } from '../components/LogTestResult';
-import { MetadataEntry, buildMetadataObject } from '../utils';
+  LogTestIntegrationOption,
+} from "../components/LogTestForm";
+import { LogTestResult } from "../components/LogTestResult";
+import { MetadataEntry, buildMetadataObject } from "../utils";
 
 const INITIAL_FORM_DATA: LogTestFormData = {
   queue: undefined,
-  location: '',
-  event: '',
-  traceLevel: 'NONE',
+  location: "",
+  event: "",
+  traceLevel: "NONE",
   space: SpaceTypes.STANDARD.value,
   metadataFields: [],
+  integration: "",
 };
 
 const INITIAL_ERRORS: LogTestFormErrors = {};
@@ -45,29 +48,57 @@ const spaceOptions: LogTestSpaceOption[] = [
   { id: SpaceTypes.TEST.value, label: SpaceTypes.TEST.label },
 ];
 
-export const LogTest: React.FC<RouteComponentProps> = () => {
+interface LogTestProps extends RouteComponentProps {
+  notifications?: NotificationsStart;
+}
+
+export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
   const [formData, setFormData] = useState<LogTestFormData>(INITIAL_FORM_DATA);
   const [errors, setErrors] = useState<LogTestFormErrors>(INITIAL_ERRORS);
   const [isLoading, setIsLoading] = useState(false);
   const [testResult, setTestResult] = useState<LogTestResponse | null>(null);
+  const [integrationOptions, setIntegrationOptions] = useState<
+    LogTestIntegrationOption[]
+  >([]);
 
   useEffect(() => {
     setBreadcrumbs([BREADCRUMBS.LOG_TEST]);
   }, []);
 
+  useEffect(() => {
+    setFormData((prev) => ({ ...prev, integration: "" }));
+    setIntegrationOptions([]);
+
+    DataStore.integrations
+      .getIntegrations(formData.space)
+      .then((integrations) => {
+        setIntegrationOptions(
+          integrations.map((i) => ({
+            id: i.id,
+            label: i.document?.metadata?.title ?? i.id,
+          })),
+        );
+      })
+      .catch((error) => {
+        console.error("Security Analytics - LogTest - getIntegrations:", error);
+        errorNotificationToast(
+          notifications,
+          "retrieve",
+          "integrations",
+          error,
+        );
+      });
+  }, [formData.space]);
+
   const validateForm = useCallback((): boolean => {
     const newErrors: LogTestFormErrors = {};
 
-    // if (formData.queue === undefined || formData.queue < 1 || formData.queue > 255) {
-    //     newErrors.queue = 'Queue is required and must be a number between 1 and 255';
-    // }
-
     if (!formData.event.trim()) {
-      newErrors.event = 'Log event is required';
+      newErrors.event = "Log event is required";
     }
 
     if (!formData.space) {
-      newErrors.space = 'Space is required';
+      newErrors.space = "Space is required";
     }
 
     setErrors(newErrors);
@@ -84,11 +115,12 @@ export const LogTest: React.FC<RouteComponentProps> = () => {
     const result = await DataStore.logTests.executeLogTest({
       document: {
         queue: 1, // temporary hardcoded queue value
-        location: String(formData.location ?? '').trim(),
+        location: String(formData.location ?? "").trim(),
         event: formData.event.trim(),
         trace_level: formData.traceLevel,
         metadata: buildMetadataObject(formData.metadataFields),
         space: formData.space,
+        integration: formData.integration || undefined,
       },
     });
 
@@ -112,7 +144,7 @@ export const LogTest: React.FC<RouteComponentProps> = () => {
         });
       }
     },
-    [errors]
+    [errors],
   );
 
   const handleMetadataFieldsChange = useCallback((fields: MetadataEntry[]) => {
@@ -145,6 +177,7 @@ export const LogTest: React.FC<RouteComponentProps> = () => {
             onFormChange={handleFormChange}
             onMetadataFieldsChange={handleMetadataFieldsChange}
             spaceOptions={spaceOptions}
+            integrationOptions={integrationOptions}
             disabled={isLoading}
           />
 
@@ -159,12 +192,16 @@ export const LogTest: React.FC<RouteComponentProps> = () => {
                 isLoading={isLoading}
                 disabled={isLoading}
               >
-                {isLoading ? 'Testing...' : 'Test'}
+                {isLoading ? "Testing..." : "Test"}
               </EuiButton>
             </EuiFlexItem>
 
             <EuiFlexItem grow={false}>
-              <EuiButton iconType="broom" onClick={handleClearSession} disabled={isLoading}>
+              <EuiButton
+                iconType="broom"
+                onClick={handleClearSession}
+                disabled={isLoading}
+              >
                 Clear session
               </EuiButton>
             </EuiFlexItem>

--- a/public/pages/LogTest/containers/LogTest.tsx
+++ b/public/pages/LogTest/containers/LogTest.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -12,33 +12,33 @@ import {
   EuiText,
   EuiButton,
   EuiHorizontalRule,
-} from "@elastic/eui";
-import { RouteComponentProps } from "react-router-dom";
-import { NotificationsStart } from "opensearch-dashboards/public";
-import { PageHeader } from "../../../components/PageHeader/PageHeader";
-import { errorNotificationToast, setBreadcrumbs } from "../../../utils/helpers";
-import { BREADCRUMBS } from "../../../utils/constants";
-import { DataStore } from "../../../store/DataStore";
-import { SpaceTypes } from "../../../../common/constants";
-import { LogTestResponse } from "../../../../types";
+} from '@elastic/eui';
+import { RouteComponentProps } from 'react-router-dom';
+import { NotificationsStart } from 'opensearch-dashboards/public';
+import { PageHeader } from '../../../components/PageHeader/PageHeader';
+import { errorNotificationToast, setBreadcrumbs } from '../../../utils/helpers';
+import { BREADCRUMBS } from '../../../utils/constants';
+import { DataStore } from '../../../store/DataStore';
+import { SpaceTypes } from '../../../../common/constants';
+import { LogTestResponse } from '../../../../types';
 import {
   LogTestForm,
   LogTestFormData,
   LogTestFormErrors,
   LogTestSpaceOption,
   LogTestIntegrationOption,
-} from "../components/LogTestForm";
-import { LogTestResult } from "../components/LogTestResult";
-import { MetadataEntry, buildMetadataObject } from "../utils";
+} from '../components/LogTestForm';
+import { LogTestResult } from '../components/LogTestResult';
+import { MetadataEntry, buildMetadataObject } from '../utils';
 
 const INITIAL_FORM_DATA: LogTestFormData = {
   queue: undefined,
-  location: "",
-  event: "",
-  traceLevel: "NONE",
+  location: '',
+  event: '',
+  traceLevel: 'NONE',
   space: SpaceTypes.STANDARD.value,
   metadataFields: [],
-  integration: "",
+  integration: '',
 };
 
 const INITIAL_ERRORS: LogTestFormErrors = {};
@@ -66,7 +66,7 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
   }, []);
 
   useEffect(() => {
-    setFormData((prev) => ({ ...prev, integration: "" }));
+    setFormData((prev) => ({ ...prev, integration: '' }));
     setIntegrationOptions([]);
 
     DataStore.integrations
@@ -82,11 +82,11 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
         );
       })
       .catch((error) => {
-        console.error("Security Analytics - LogTest - getIntegrations:", error);
+        console.error('Security Analytics - LogTest - getIntegrations:', error);
         errorNotificationToast(
           notifications,
-          "retrieve",
-          "integrations",
+          'retrieve',
+          'integrations',
           error,
         );
       });
@@ -96,11 +96,11 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
     const newErrors: LogTestFormErrors = {};
 
     if (!formData.event.trim()) {
-      newErrors.event = "Log event is required";
+      newErrors.event = 'Log event is required';
     }
 
     if (!formData.space) {
-      newErrors.space = "Space is required";
+      newErrors.space = 'Space is required';
     }
 
     setErrors(newErrors);
@@ -117,7 +117,7 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
     const result = await DataStore.logTests.executeLogTest({
       document: {
         queue: 1, // temporary hardcoded queue value
-        location: String(formData.location ?? "").trim(),
+        location: String(formData.location ?? '').trim(),
         event: formData.event.trim(),
         trace_level: formData.traceLevel,
         metadata: buildMetadataObject(formData.metadataFields),
@@ -160,16 +160,16 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
   }, []);
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="m">
+    <EuiFlexGroup direction='column' gutterSize='m'>
       <EuiFlexItem grow={false}>
         <PageHeader>
-          <EuiText size="s">
+          <EuiText size='s'>
             <h1>Log Test</h1>
           </EuiText>
         </PageHeader>
       </EuiFlexItem>
 
-      <EuiSpacer size="m" />
+      <EuiSpacer size='m' />
 
       <EuiFlexItem>
         <EuiPanel>
@@ -183,24 +183,24 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
             disabled={isLoading}
           />
 
-          <EuiSpacer size="l" />
+          <EuiSpacer size='l' />
 
-          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+          <EuiFlexGroup justifyContent='spaceBetween' alignItems='center'>
             <EuiFlexItem grow={false}>
               <EuiButton
                 fill
-                iconType="play"
+                iconType='play'
                 onClick={handleExecuteLogTest}
                 isLoading={isLoading}
                 disabled={isLoading}
               >
-                {isLoading ? "Testing..." : "Test"}
+                {isLoading ? 'Testing...' : 'Test'}
               </EuiButton>
             </EuiFlexItem>
 
             <EuiFlexItem grow={false}>
               <EuiButton
-                iconType="broom"
+                iconType='broom'
                 onClick={handleClearSession}
                 disabled={isLoading}
               >
@@ -211,7 +211,7 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
 
           {testResult && (
             <>
-              <EuiHorizontalRule margin="l" />
+              <EuiHorizontalRule margin='l' />
               <LogTestResult result={testResult} />
             </>
           )}

--- a/public/pages/LogTest/containers/LogTest.tsx
+++ b/public/pages/LogTest/containers/LogTest.tsx
@@ -73,10 +73,12 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
       .getIntegrations(formData.space)
       .then((integrations) => {
         setIntegrationOptions(
-          integrations.map((i) => ({
-            id: i.id,
-            label: i.document?.metadata?.title ?? i.id,
-          })),
+          integrations
+            .filter((i) => i.document?.enabled)
+            .map((i) => ({
+              id: i.id,
+              label: i.document?.metadata?.title ?? i.id,
+            })),
         );
       })
       .catch((error) => {

--- a/public/pages/LogTest/containers/LogTest.tsx
+++ b/public/pages/LogTest/containers/LogTest.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -43,10 +43,17 @@ const INITIAL_FORM_DATA: LogTestFormData = {
 
 const INITIAL_ERRORS: LogTestFormErrors = {};
 
-const spaceOptions: LogTestSpaceOption[] = [
+const INITIAL_SPACE_OPTIONS: LogTestSpaceOption[] = [
   { id: SpaceTypes.STANDARD.value, label: SpaceTypes.STANDARD.label },
   { id: SpaceTypes.TEST.value, label: SpaceTypes.TEST.label },
 ];
+
+interface SpaceCacheEntry {
+  enabled: boolean;
+  integrations: LogTestIntegrationOption[];
+}
+
+type SpaceCache = Record<string, SpaceCacheEntry>;
 
 interface LogTestProps extends RouteComponentProps {
   notifications?: NotificationsStart;
@@ -57,40 +64,81 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
   const [errors, setErrors] = useState<LogTestFormErrors>(INITIAL_ERRORS);
   const [isLoading, setIsLoading] = useState(false);
   const [testResult, setTestResult] = useState<LogTestResponse | null>(null);
-  const [integrationOptions, setIntegrationOptions] = useState<
-    LogTestIntegrationOption[]
-  >([]);
+  const [spaceCache, setSpaceCache] = useState<SpaceCache>({});
 
   useEffect(() => {
     setBreadcrumbs([BREADCRUMBS.LOG_TEST]);
   }, []);
 
-  useEffect(() => {
-    setFormData((prev) => ({ ...prev, integration: '' }));
-    setIntegrationOptions([]);
+  const refreshSpaceCache = useCallback(async (): Promise<SpaceCache> => {
+    const entries = await Promise.all(
+      INITIAL_SPACE_OPTIONS.map((option) =>
+        DataStore.policies
+          .searchPolicies(option.id, { includeIntegrationFields: ['document'] })
+          .then((response): [string, SpaceCacheEntry] => {
+            const policy = response.items[0];
+            const integrations: LogTestIntegrationOption[] = Object.values(
+              policy?.integrationsMap ?? {}
+            )
+              .filter((i) => i.document?.enabled)
+              .map((i) => ({
+                id: i.document?.id,
+                label: i.document?.metadata?.title ?? i.document?.id,
+              }));
+            return [
+              option.id,
+              {
+                enabled: !!policy && policy.document?.enabled !== false,
+                integrations,
+              },
+            ];
+          })
+          .catch((error): [string, SpaceCacheEntry] => {
+            console.error(`Security Analytics - LogTest - searchPolicies (${option.id}):`, error);
+            errorNotificationToast(notifications, 'retrieve', 'policies', error);
+            return [option.id, { enabled: false, integrations: [] }];
+          })
+      )
+    );
 
-    DataStore.integrations
-      .getIntegrations(formData.space)
-      .then((integrations) => {
-        setIntegrationOptions(
-          integrations
-            .filter((i) => i.document?.enabled)
-            .map((i) => ({
-              id: i.id,
-              label: i.document?.metadata?.title ?? i.id,
-            })),
-        );
-      })
-      .catch((error) => {
-        console.error('Security Analytics - LogTest - getIntegrations:', error);
-        errorNotificationToast(
-          notifications,
-          'retrieve',
-          'integrations',
-          error,
-        );
-      });
+    const cache: SpaceCache = Object.fromEntries(entries);
+    setSpaceCache(cache);
+    setFormData((prev) => {
+      if (cache[prev.space]?.enabled) return prev;
+      const firstEnabledId = INITIAL_SPACE_OPTIONS.find((o) => cache[o.id]?.enabled)?.id;
+      if (!firstEnabledId || firstEnabledId === prev.space) return prev;
+      return { ...prev, space: firstEnabledId, integration: '' };
+    });
+    return cache;
+  }, [notifications]);
+
+  useEffect(() => {
+    refreshSpaceCache();
+  }, [refreshSpaceCache]);
+
+  useEffect(() => {
+    setFormData((prev) => (prev.integration ? { ...prev, integration: '' } : prev));
   }, [formData.space]);
+
+  const spaceOptions = useMemo<LogTestSpaceOption[]>(
+    () =>
+      INITIAL_SPACE_OPTIONS.map((option) => {
+        const isEnabled = spaceCache[option.id]?.enabled ?? false;
+        return {
+          ...option,
+          disabled: !isEnabled,
+          title: !isEnabled
+            ? `The "${option.label}" space is disabled , please enable it`
+            : undefined,
+        };
+      }),
+    [spaceCache]
+  );
+
+  const integrationOptions = useMemo<LogTestIntegrationOption[]>(
+    () => spaceCache[formData.space]?.integrations ?? [],
+    [spaceCache, formData.space]
+  );
 
   const validateForm = useCallback((): boolean => {
     const newErrors: LogTestFormErrors = {};
@@ -131,6 +179,8 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
     if (result.success && result.data) {
       setTestResult(result.data);
     }
+
+    refreshSpaceCache();
   };
 
   const handleFormChange = useCallback(
@@ -146,7 +196,7 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
         });
       }
     },
-    [errors],
+    [errors]
   );
 
   const handleMetadataFieldsChange = useCallback((fields: MetadataEntry[]) => {
@@ -160,16 +210,16 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
   }, []);
 
   return (
-    <EuiFlexGroup direction='column' gutterSize='m'>
+    <EuiFlexGroup direction="column" gutterSize="m">
       <EuiFlexItem grow={false}>
         <PageHeader>
-          <EuiText size='s'>
+          <EuiText size="s">
             <h1>Log Test</h1>
           </EuiText>
         </PageHeader>
       </EuiFlexItem>
 
-      <EuiSpacer size='m' />
+      <EuiSpacer size="m" />
 
       <EuiFlexItem>
         <EuiPanel>
@@ -183,13 +233,13 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
             disabled={isLoading}
           />
 
-          <EuiSpacer size='l' />
+          <EuiSpacer size="l" />
 
-          <EuiFlexGroup justifyContent='spaceBetween' alignItems='center'>
+          <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
             <EuiFlexItem grow={false}>
               <EuiButton
                 fill
-                iconType='play'
+                iconType="play"
                 onClick={handleExecuteLogTest}
                 isLoading={isLoading}
                 disabled={isLoading}
@@ -199,11 +249,7 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
             </EuiFlexItem>
 
             <EuiFlexItem grow={false}>
-              <EuiButton
-                iconType='broom'
-                onClick={handleClearSession}
-                disabled={isLoading}
-              >
+              <EuiButton iconType="broom" onClick={handleClearSession} disabled={isLoading}>
                 Clear session
               </EuiButton>
             </EuiFlexItem>
@@ -211,7 +257,7 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
 
           {testResult && (
             <>
-              <EuiHorizontalRule margin='l' />
+              <EuiHorizontalRule margin="l" />
               <LogTestResult result={testResult} />
             </>
           )}

--- a/public/pages/LogTest/containers/LogTest.tsx
+++ b/public/pages/LogTest/containers/LogTest.tsx
@@ -74,7 +74,9 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
     const entries = await Promise.all(
       INITIAL_SPACE_OPTIONS.map((option) =>
         DataStore.policies
-          .searchPolicies(option.id, { includeIntegrationFields: ['document'] })
+          .searchPolicies(option.id, {
+            includeIntegrationFields: ['document.id', 'document.metadata', 'document.enabled'],
+          })
           .then((response): [string, SpaceCacheEntry] => {
             const policy = response.items[0];
             const integrations: LogTestIntegrationOption[] = Object.values(
@@ -114,7 +116,8 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
 
   useEffect(() => {
     refreshSpaceCache();
-  }, [refreshSpaceCache]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     setFormData((prev) => (prev.integration ? { ...prev, integration: '' } : prev));

--- a/public/pages/LogTest/containers/LogTest.tsx
+++ b/public/pages/LogTest/containers/LogTest.tsx
@@ -179,8 +179,6 @@ export const LogTest: React.FC<LogTestProps> = ({ notifications }) => {
     if (result.success && result.data) {
       setTestResult(result.data);
     }
-
-    refreshSpaceCache();
   };
 
   const handleFormChange = useCallback(

--- a/server/routes/LogTestRoutes.ts
+++ b/server/routes/LogTestRoutes.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { IRouter } from "opensearch-dashboards/server";
-import { schema } from "@osd/config-schema";
-import { NodeServices } from "../models/interfaces";
-import { API } from "../utils/constants";
-import { createQueryValidationSchema } from "../utils/helpers";
+import { IRouter } from 'opensearch-dashboards/server';
+import { schema } from '@osd/config-schema';
+import { NodeServices } from '../models/interfaces';
+import { API } from '../utils/constants';
+import { createQueryValidationSchema } from '../utils/helpers';
 
 export function setupLogTestRoutes(services: NodeServices, router: IRouter) {
   const { logTestService } = services;
@@ -26,9 +26,9 @@ export function setupLogTestRoutes(services: NodeServices, router: IRouter) {
             event: schema.string(),
             trace_level: schema.maybe(
               schema.oneOf([
-                schema.literal("NONE"),
-                schema.literal("ASSET_ONLY"),
-                schema.literal("ALL"),
+                schema.literal('NONE'),
+                schema.literal('ASSET_ONLY'),
+                schema.literal('ALL'),
               ]),
             ),
             space: schema.string(),

--- a/server/routes/LogTestRoutes.ts
+++ b/server/routes/LogTestRoutes.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { IRouter } from 'opensearch-dashboards/server';
-import { schema } from '@osd/config-schema';
-import { NodeServices } from '../models/interfaces';
-import { API } from '../utils/constants';
-import { createQueryValidationSchema } from '../utils/helpers';
+import { IRouter } from "opensearch-dashboards/server";
+import { schema } from "@osd/config-schema";
+import { NodeServices } from "../models/interfaces";
+import { API } from "../utils/constants";
+import { createQueryValidationSchema } from "../utils/helpers";
 
 export function setupLogTestRoutes(services: NodeServices, router: IRouter) {
   const { logTestService } = services;
@@ -20,21 +20,24 @@ export function setupLogTestRoutes(services: NodeServices, router: IRouter) {
           document: schema.object({
             queue: schema.number(),
             location: schema.string(),
-            metadata: schema.maybe(schema.recordOf(schema.string(), schema.any())),
+            metadata: schema.maybe(
+              schema.recordOf(schema.string(), schema.any()),
+            ),
             event: schema.string(),
             trace_level: schema.maybe(
               schema.oneOf([
-                schema.literal('NONE'),
-                schema.literal('ASSET_ONLY'),
-                schema.literal('ALL'),
-              ])
+                schema.literal("NONE"),
+                schema.literal("ASSET_ONLY"),
+                schema.literal("ALL"),
+              ]),
             ),
             space: schema.string(),
+            integration: schema.maybe(schema.string()),
           }),
         }),
         query: createQueryValidationSchema(),
       },
     },
-    logTestService.logTest
+    logTestService.logTest,
   );
 }

--- a/types/LogTest.ts
+++ b/types/LogTest.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-export type LogTestTraceLevel = "NONE" | "ASSET_ONLY" | "ALL";
+export type LogTestTraceLevel = 'NONE' | 'ASSET_ONLY' | 'ALL';
 
 export interface LogTestRequestBody {
   queue: number;
@@ -23,7 +23,7 @@ export interface LogTestAssetTrace {
 
 export interface LogTestValidationError {
   path: string;
-  kind: "unknown_field" | "invalid_type" | "temporary_field_not_allowed";
+  kind: 'unknown_field' | 'invalid_type' | 'temporary_field_not_allowed';
   expected?: string | null;
   actual?: string | null;
   [key: string]: unknown;
@@ -40,7 +40,7 @@ export interface LogTestNormalizationResult {
   validation?: LogTestValidation;
 }
 
-export type LogTestDetectionStatus = "success" | "skipped" | "error";
+export type LogTestDetectionStatus = 'success' | 'skipped' | 'error';
 
 export interface LogTestDetectionRuleMatch {
   rule: {

--- a/types/LogTest.ts
+++ b/types/LogTest.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-export type LogTestTraceLevel = 'NONE' | 'ASSET_ONLY' | 'ALL';
+export type LogTestTraceLevel = "NONE" | "ASSET_ONLY" | "ALL";
 
 export interface LogTestRequestBody {
   queue: number;
@@ -12,6 +12,7 @@ export interface LogTestRequestBody {
   event: string;
   trace_level?: LogTestTraceLevel;
   space: string;
+  integration?: string;
 }
 
 export interface LogTestAssetTrace {
@@ -20,19 +21,9 @@ export interface LogTestAssetTrace {
   traces: string[];
 }
 
-export interface LogTestMatchedRule {
-  id?: string;
-  rule_id?: string;
-  name?: string;
-  title?: string;
-  level?: string;
-  severity?: string;
-  [key: string]: unknown;
-}
-
 export interface LogTestValidationError {
   path: string;
-  kind: 'unknown_field' | 'invalid_type' | 'temporary_field_not_allowed';
+  kind: "unknown_field" | "invalid_type" | "temporary_field_not_allowed";
   expected?: string | null;
   actual?: string | null;
   [key: string]: unknown;
@@ -43,16 +34,40 @@ export interface LogTestValidation {
   errors: LogTestValidationError[];
 }
 
-export interface LogTestResult {
+export interface LogTestNormalizationResult {
   output: object;
   asset_traces?: LogTestAssetTrace[];
-  matched_rules?: LogTestMatchedRule[];
   validation?: LogTestValidation;
+}
+
+export type LogTestDetectionStatus = "success" | "skipped" | "failure";
+
+export interface LogTestDetectionRuleMatch {
+  rule: {
+    id: string;
+    title: string;
+    level: string;
+    tags: string[];
+  };
+  matched_conditions: string[];
+}
+
+export interface LogTestDetectionResult {
+  status: LogTestDetectionStatus;
+  rules_evaluated?: number;
+  rules_matched?: number;
+  matches?: LogTestDetectionRuleMatch[];
+  reason?: string;
+}
+
+export interface LogTestResponseMessage {
+  normalization: LogTestNormalizationResult;
+  detection: LogTestDetectionResult;
 }
 
 export interface LogTestResponse {
   status: string;
-  message: LogTestResult;
+  message: LogTestResponseMessage;
 }
 
 export interface LogTestApiRequest {

--- a/types/LogTest.ts
+++ b/types/LogTest.ts
@@ -40,7 +40,7 @@ export interface LogTestNormalizationResult {
   validation?: LogTestValidation;
 }
 
-export type LogTestDetectionStatus = "success" | "skipped" | "failure";
+export type LogTestDetectionStatus = "success" | "skipped" | "error";
 
 export interface LogTestDetectionRuleMatch {
   rule: {


### PR DESCRIPTION
### Description
  - Add integration selector to the Log Test form, populated dynamically based on selected space
  - Split results UI into Normalization and Detection tabs                                                             
  - Update response types to match new API structure (normalization + detection sections)
  - Display matched detection rules with severity badges, tags, and matched conditions 


### Issues Resolved
- closes  #187

### Evidence

https://github.com/user-attachments/assets/3b1b4443-ed44-4450-8dd6-b95ebda52288

### Test
  1. Navigate to Log Test page and verify the form is split into two sections: Normalization and Detection.            
  2. Verify the Detection section has an Integration dropdown (optional).                                              
  3. Change the Space and verify the Integration dropdown resets and reloads integrations for that space.              
  4. Submit a log test without an integration selected.                                                            
  5. Submit a log test with an integration selected.     

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 
