### PR TITLE
Enhance error handling and notifications in DecoderFormPage and Decod…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@ All notable changes to the Wazuh ML Commons project will be documented in this f
 - Fixed YAML Editor when creating or editing detection rules [#9](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/9)
 - Fixed detection rule editor causing blank screen [#44](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/44)
 - Fixed data source didn't include data stream aliases for detector creation [#116](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/116)
+- Fixed decoders form not handling request errors properly [#194](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/194)

--- a/public/pages/Decoders/containers/DecoderFormPage.tsx
+++ b/public/pages/Decoders/containers/DecoderFormPage.tsx
@@ -129,20 +129,29 @@ export const DecoderFormPage: React.FC<DecoderFormPageProps> = (props) => {
         return;
       }
 
-      const result = await DataStore.decoders.createDecoder({
-        document: values,
-        integrationId: integrationType,
-      });
+      try {
+        const result = await DataStore.decoders.createDecoder({
+          document: values,
+          integrationId: integrationType,
+        });
 
-      if (result) {
-        successNotificationToast(
+        if (result) {
+          successNotificationToast(
+            notifications,
+            'create',
+            'decoder',
+            result.message || `The decoder ${values.name} has been created successfully.`
+          );
+
+          history.push(`${ROUTES.DECODERS}`);
+        }
+      } catch (error: any) {
+        errorNotificationToast(
           notifications,
           'create',
           'decoder',
-          result.message || `The decoder ${values.name} has been created successfully.`
+          error?.message || 'An unexpected error occurred while creating the decoder.'
         );
-
-        history.push(`${ROUTES.DECODERS}`);
       }
     },
     [integrationType, notifications, history]
@@ -155,19 +164,28 @@ export const DecoderFormPage: React.FC<DecoderFormPageProps> = (props) => {
         return;
       }
 
-      const result = await DataStore.decoders.updateDecoder(idDecoder, {
-        document: values,
-      });
+      try {
+        const result = await DataStore.decoders.updateDecoder(idDecoder, {
+          document: values,
+        });
 
-      if (result) {
-        successNotificationToast(
+        if (result) {
+          successNotificationToast(
+            notifications,
+            'update',
+            'decoder',
+            result.message || `The decoder ${values.name} has been updated successfully.`
+          );
+
+          history.push(`${ROUTES.DECODERS}`);
+        }
+      } catch (error: any) {
+        errorNotificationToast(
           notifications,
           'update',
           'decoder',
-          result.message || `The decoder ${values.name} has been updated successfully.`
+          error?.message || 'An unexpected error occurred while updating the decoder.'
         );
-
-        history.push(`${ROUTES.DECODERS}`);
       }
     },
     [notifications, history]

--- a/public/services/DecodersService.ts
+++ b/public/services/DecodersService.ts
@@ -38,56 +38,84 @@ export default class DecodersService {
     return undefined;
   }
 
+  private parseHttpError(error: any): string {
+    return error?.body?.message || error?.body?.error || error?.message || 'Unknown error';
+  }
+
   searchDecoders = async (
     body: any,
     space?: string
   ): Promise<ServerResponse<SearchDecodersResponse>> => {
-    const url = `${this.baseUrl}/_search`;
-    const normalizedSpace = this.normalizeSpace(space);
-    const query = normalizedSpace ? { space: normalizedSpace } : {};
-    return await this.httpClient.post(url, {
-      query,
-      body: JSON.stringify(body),
-    });
+    try {
+      const url = `${this.baseUrl}/_search`;
+      const normalizedSpace = this.normalizeSpace(space);
+      const query = normalizedSpace ? { space: normalizedSpace } : {};
+      return await this.httpClient.post(url, {
+        query,
+        body: JSON.stringify(body),
+      });
+    } catch (error: any) {
+      return { ok: false, error: this.parseHttpError(error) };
+    }
   };
 
   getDecoder = async (
     decoderId: string,
     space: string
   ): Promise<ServerResponse<GetDecoderResponse>> => {
-    const url = `${this.baseUrl}/${decoderId}`;
-    const normalizedSpace = this.normalizeSpace(space);
-    const query = normalizedSpace ? { space: normalizedSpace } : {};
-    return (await this.httpClient.get(url, { query })) as ServerResponse<GetDecoderResponse>;
+    try {
+      const url = `${this.baseUrl}/${decoderId}`;
+      const normalizedSpace = this.normalizeSpace(space);
+      const query = normalizedSpace ? { space: normalizedSpace } : {};
+      return (await this.httpClient.get(url, { query })) as ServerResponse<GetDecoderResponse>;
+    } catch (error: any) {
+      return { ok: false, error: this.parseHttpError(error) };
+    }
   };
 
   createDecoder = async (body: {
     document: any;
     integrationId: string;
   }): Promise<ServerResponse<CUDDecoderResponse>> => {
-    const url = `${this.baseUrl}`;
-    return await this.httpClient.post(url, {
-      body: JSON.stringify(body),
-    });
+    try {
+      const url = `${this.baseUrl}`;
+      return await this.httpClient.post(url, {
+        body: JSON.stringify(body),
+      });
+    } catch (error: any) {
+      return { ok: false, error: this.parseHttpError(error) };
+    }
   };
 
   updateDecoder = async (
     decoderId: string,
     body: { document: any }
   ): Promise<ServerResponse<CUDDecoderResponse>> => {
-    const url = `${this.baseUrl}/${decoderId}`;
-    return await this.httpClient.put(url, {
-      body: JSON.stringify(body),
-    });
+    try {
+      const url = `${this.baseUrl}/${decoderId}`;
+      return await this.httpClient.put(url, {
+        body: JSON.stringify(body),
+      });
+    } catch (error: any) {
+      return { ok: false, error: this.parseHttpError(error) };
+    }
   };
 
   deleteDecoder = async (decoderId: string): Promise<ServerResponse<CUDDecoderResponse>> => {
-    const url = `${this.baseUrl}/${decoderId}`;
-    return await this.httpClient.delete(url, {});
+    try {
+      const url = `${this.baseUrl}/${decoderId}`;
+      return await this.httpClient.delete(url, {});
+    } catch (error: any) {
+      return { ok: false, error: this.parseHttpError(error) };
+    }
   };
 
   getDraftIntegrations = async (): Promise<ServerResponse<any>> => {
-    const url = `${this.baseUrl}/integrations/draft`;
-    return await this.httpClient.get(url, {});
+    try {
+      const url = `${this.baseUrl}/integrations/draft`;
+      return await this.httpClient.get(url, {});
+    } catch (error: any) {
+      return { ok: false, error: this.parseHttpError(error) };
+    }
   };
 }


### PR DESCRIPTION
### Description

Fixes error handling in the decoders form so that backend and validation errors are always surfaced to the user via a toast notification.

### Issues Resolved

Resolves #188

### Evidence
<img width="1900" height="933" alt="image" src="https://github.com/user-attachments/assets/f95b7629-6f75-4ed3-9316-5f5569010904" />

### Test
Cause and  error on YAML and validate that toast displays correctly

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).