### PR TITLE
Create filter by raw YAML code editor

### DIFF
--- a/public/components/YamlForm/components/YamlForm.tsx
+++ b/public/components/YamlForm/components/YamlForm.tsx
@@ -1,10 +1,11 @@
 import React, { useRef, useState } from 'react';
 import { EuiCompressedFormRow, EuiCodeEditor, EuiSpacer, EuiText, EuiCallOut } from '@elastic/eui';
 import FormFieldHeader from '../../../components/FormFieldHeader';
-import { YamlEditorState } from '../../Rules/components/RuleEditor/components/YamlRuleEditorComponent/YamlRuleEditorComponent';
+import { YamlEditorState, YAML_TYPE } from '../utils/constants';
 
 interface YamlFormProps {
-  rawDecoder: string;
+  type: YAML_TYPE;
+  value: string;
   change: React.Dispatch<string>;
   isInvalid: boolean;
   errors?: string[];
@@ -12,7 +13,8 @@ interface YamlFormProps {
 }
 
 export const YamlForm: React.FC<YamlFormProps> = ({
-  rawDecoder,
+  type,
+  value,
   change,
   isInvalid,
   errors,
@@ -20,7 +22,7 @@ export const YamlForm: React.FC<YamlFormProps> = ({
 }) => {
   const [state, setState] = useState<YamlEditorState>({
     errors: null,
-    value: rawDecoder ?? '',
+    value: value ?? '',
   });
 
   const isFocusedRef = useRef(false);
@@ -33,7 +35,7 @@ export const YamlForm: React.FC<YamlFormProps> = ({
 
   const tryParseAndNotify = (value: string) => {
     if (!value || value.trim() === '') {
-      setState((prev) => ({ ...prev, errors: ['Decoder cannot be empty'] }));
+      setState((prev) => ({ ...prev, errors: [`${type} cannot be empty`] }));
       return;
     }
     try {
@@ -41,7 +43,7 @@ export const YamlForm: React.FC<YamlFormProps> = ({
       setState((prev) => ({ ...prev, errors: null }));
     } catch (err) {
       setState((prev) => ({ ...prev, errors: ['Invalid YAML'] }));
-      console.warn('Security Analytics - Decoder Editor - Yaml load', err);
+      console.warn(`Security Analytics - ${type} Editor - Yaml load`, err);
     }
   };
 
@@ -87,13 +89,13 @@ export const YamlForm: React.FC<YamlFormProps> = ({
       {renderErrors()}
       <EuiSpacer size="s" />
       <EuiCompressedFormRow
-        label={<FormFieldHeader headerTitle={'Define decoder in YAML'} />}
+        label={<FormFieldHeader headerTitle={`Define ${type} in YAML`} />}
         fullWidth={true}
       >
         <>
           <EuiSpacer />
           <EuiText size="s" color="subdued">
-            Use the YAML editor to define a custom decoder.
+            Use the YAML editor to define a custom {type}.
           </EuiText>
           <EuiSpacer size="s" />
           <EuiCodeEditor

--- a/public/components/YamlForm/index.ts
+++ b/public/components/YamlForm/index.ts
@@ -1,0 +1,3 @@
+export { mapYamlToLosslessDecoder } from './utils/helpers';
+export { YamlForm } from './components/YamlForm';
+export { YAML_TYPE, YamlEditorState } from './utils/constants';

--- a/public/components/YamlForm/index.ts
+++ b/public/components/YamlForm/index.ts
@@ -1,3 +1,3 @@
-export { mapYamlToLosslessDecoder } from './utils/helpers';
+export { mapYamlToLosslessObject } from './utils/helpers';
 export { YamlForm } from './components/YamlForm';
 export { YAML_TYPE, YamlEditorState } from './utils/constants';

--- a/public/components/YamlForm/utils/constants.ts
+++ b/public/components/YamlForm/utils/constants.ts
@@ -1,0 +1,9 @@
+export interface YamlEditorState {
+  errors: string[] | null;
+  value?: string;
+}
+
+export enum YAML_TYPE {
+  DECODER = 'Decoder',
+  FILTER = 'Filter',
+}

--- a/public/components/YamlForm/utils/helpers.ts
+++ b/public/components/YamlForm/utils/helpers.ts
@@ -1,8 +1,8 @@
 import YAML from 'yaml';
 import { LosslessNumber } from 'lossless-json';
 
-// Convert yaml string to a decoder model with floats with decimal precision
-export const mapYamlToLosslessDecoder = <T>(yamlString: string): T => {
+// Convert yaml string to a object model with floats with decimal precision
+export const mapYamlToLosslessObject = <T>(yamlString: string): T => {
   const yamlObject = YAML.parseDocument(yamlString);
 
   YAML.visit(yamlObject, {

--- a/public/components/YamlForm/utils/helpers.ts
+++ b/public/components/YamlForm/utils/helpers.ts
@@ -1,21 +1,8 @@
-import { DecoderDocument } from '../../../../types/Decoders';
 import YAML from 'yaml';
 import { LosslessNumber } from 'lossless-json';
 
-export const decoderFormDefaultValue: string = `name: decoder/<name>/<version>
-enabled: true
-metadata:
-  title: Placeholder Decoder
-  description: This is a placeholder decoder. Please update the fields accordingly.
-  author: User
-  date: '${new Date().toISOString().split('T')[0]}'
-  modified: '${new Date().toISOString().split('T')[0]}'
-  references: []
-  documentation: ''
-  supports: []`;
-
 // Convert yaml string to a decoder model with floats with decimal precision
-export const mapYamlToLosslessDecoder = (yamlString: string): DecoderDocument => {
+export const mapYamlToLosslessDecoder = <T>(yamlString: string): T => {
   const yamlObject = YAML.parseDocument(yamlString);
 
   YAML.visit(yamlObject, {
@@ -38,7 +25,7 @@ export const mapYamlToLosslessDecoder = (yamlString: string): DecoderDocument =>
   });
 
   // Transform the yaml into an object with lossless numbers
-  const decoderForm = yamlObject.toJS() as DecoderDocument;
+  const objectForm = yamlObject.toJS() as T;
 
-  return decoderForm;
+  return objectForm;
 };

--- a/public/pages/Decoders/components/DecoderDetailsFlyout.tsx
+++ b/public/pages/Decoders/components/DecoderDetailsFlyout.tsx
@@ -28,7 +28,7 @@ import { Metadata } from '../../../components/Utility/Metadata';
 import { DEFAULT_EMPTY_DATA } from '../../../utils/constants';
 import { BadgeGroup } from '../../../components/Utility/BadgeGroup';
 import { stringify as LosslessStringify } from 'lossless-json';
-import { mapYamlToLosslessDecoder } from '../../../components/YamlForm';
+import { mapYamlToLosslessObject } from '../../../components/YamlForm';
 
 interface DecoderDetailsFlyoutProps {
   decoderId: string;
@@ -99,7 +99,7 @@ export const DecoderDetailsFlyout: React.FC<DecoderDetailsFlyoutProps> = ({
     try {
       const rawYaml = typeof decoder.decoder === 'string' ? decoder.decoder : null;
       if (rawYaml) {
-        const losslessDoc = mapYamlToLosslessDecoder<DecoderDocument>(rawYaml);
+        const losslessDoc = mapYamlToLosslessObject<DecoderDocument>(rawYaml);
         return LosslessStringify(losslessDoc, null, 2) ?? '';
       }
       return JSON.stringify(decoder?.document, null, 2);

--- a/public/pages/Decoders/components/DecoderDetailsFlyout.tsx
+++ b/public/pages/Decoders/components/DecoderDetailsFlyout.tsx
@@ -21,14 +21,14 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
-import { DecoderItem } from '../../../../types';
+import { DecoderDocument, DecoderItem } from '../../../../types';
 import { DataStore } from '../../../store/DataStore';
 import { EnabledHealth } from '../../../components/Utility/EnabledHealth';
 import { Metadata } from '../../../components/Utility/Metadata';
 import { DEFAULT_EMPTY_DATA } from '../../../utils/constants';
 import { BadgeGroup } from '../../../components/Utility/BadgeGroup';
 import { stringify as LosslessStringify } from 'lossless-json';
-import { mapYamlToLosslessDecoder } from '../components/mappers';
+import { mapYamlToLosslessDecoder } from '../../../components/YamlForm';
 
 interface DecoderDetailsFlyoutProps {
   decoderId: string;
@@ -95,12 +95,11 @@ export const DecoderDetailsFlyout: React.FC<DecoderDetailsFlyoutProps> = ({
   }, [decoderId, space]);
 
   const decoderJson = useMemo(() => {
-    if (!decoder) return "";
+    if (!decoder) return '';
     try {
-      const rawYaml =
-        typeof decoder.decoder === 'string' ? decoder.decoder : null;
+      const rawYaml = typeof decoder.decoder === 'string' ? decoder.decoder : null;
       if (rawYaml) {
-        const losslessDoc = mapYamlToLosslessDecoder(rawYaml);
+        const losslessDoc = mapYamlToLosslessDecoder<DecoderDocument>(rawYaml);
         return LosslessStringify(losslessDoc, null, 2) ?? '';
       }
       return JSON.stringify(decoder?.document, null, 2);

--- a/public/pages/Decoders/containers/DecoderFormPage.tsx
+++ b/public/pages/Decoders/containers/DecoderFormPage.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { Form, Formik, FormikErrors } from 'formik';
-import { decoderFormDefaultValue, mapYamlToLosslessDecoder } from '../components/mappers';
-import { YamlForm } from '../components/YamlForm';
+import { decoderFormDefaultValue } from '../utils/constants';
+import { YamlForm, YAML_TYPE, mapYamlToLosslessDecoder } from '../../../components/YamlForm';
 import {
   errorNotificationToast,
   setBreadcrumbs,
@@ -28,7 +28,6 @@ import {
 import { DecoderDocument } from '../../../../types/Decoders';
 import { DataStore } from '../../../store/DataStore';
 import { RouteComponentProps } from 'react-router-dom';
-import { validate } from 'joi';
 
 const editorTypes = [
   {
@@ -72,7 +71,7 @@ export const DecoderFormPage: React.FC<DecoderFormPageProps> = (props) => {
         try {
           const response = await DataStore.decoders.getDecoder(idDecoder, spaceDecoder);
           setRawDecoder(response?.decoder ?? decoderFormDefaultValue);
-          setDecoder(mapYamlToLosslessDecoder(response?.decoder ?? ''));
+          setDecoder(mapYamlToLosslessDecoder<DecoderDocument>(response?.decoder ?? ''));
           setIntegrationType(response?.integrations?.[0] || '');
           setBreadcrumbs([
             BREADCRUMBS.NORMALIZATION,
@@ -200,7 +199,7 @@ export const DecoderFormPage: React.FC<DecoderFormPageProps> = (props) => {
     const errors: FormikErrors<DecoderDocument> = {};
 
     // FIXME: This is making a transformation on each detected change in the yaml form, this could create a lot of overhead
-    const decoder = mapYamlToLosslessDecoder(values.rawDecoder);
+    const decoder = mapYamlToLosslessDecoder<DecoderDocument>(values.rawDecoder);
 
     if (!decoder.name) {
       errors.name = 'Decoder name is required';
@@ -249,7 +248,7 @@ export const DecoderFormPage: React.FC<DecoderFormPageProps> = (props) => {
           validate={validateForm}
           onSubmit={(values, { setSubmitting }) => {
             setSubmitting(false);
-            handleOnClick(mapYamlToLosslessDecoder(values.rawDecoder));
+            handleOnClick(mapYamlToLosslessDecoder<DecoderDocument>(values.rawDecoder));
           }}
         >
           {(props) => (
@@ -295,7 +294,8 @@ export const DecoderFormPage: React.FC<DecoderFormPageProps> = (props) => {
 
                 {selectedEditorType === 'yaml' && (
                   <YamlForm
-                    rawDecoder={props.values.rawDecoder}
+                    type={YAML_TYPE.DECODER}
+                    value={props.values.rawDecoder}
                     isInvalid={Object.keys(props.errors).length > 0}
                     errors={Object.keys(props.errors).map(
                       (key) => (props.errors as Record<string, string>)[key]

--- a/public/pages/Decoders/containers/DecoderFormPage.tsx
+++ b/public/pages/Decoders/containers/DecoderFormPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { Form, Formik, FormikErrors } from 'formik';
 import { decoderFormDefaultValue } from '../utils/constants';
-import { YamlForm, YAML_TYPE, mapYamlToLosslessDecoder } from '../../../components/YamlForm';
+import { YamlForm, YAML_TYPE, mapYamlToLosslessObject } from '../../../components/YamlForm';
 import {
   errorNotificationToast,
   setBreadcrumbs,
@@ -71,7 +71,7 @@ export const DecoderFormPage: React.FC<DecoderFormPageProps> = (props) => {
         try {
           const response = await DataStore.decoders.getDecoder(idDecoder, spaceDecoder);
           setRawDecoder(response?.decoder ?? decoderFormDefaultValue);
-          setDecoder(mapYamlToLosslessDecoder<DecoderDocument>(response?.decoder ?? ''));
+          setDecoder(mapYamlToLosslessObject<DecoderDocument>(response?.decoder ?? ''));
           setIntegrationType(response?.integrations?.[0] || '');
           setBreadcrumbs([
             BREADCRUMBS.NORMALIZATION,
@@ -199,7 +199,7 @@ export const DecoderFormPage: React.FC<DecoderFormPageProps> = (props) => {
     const errors: FormikErrors<DecoderDocument> = {};
 
     // FIXME: This is making a transformation on each detected change in the yaml form, this could create a lot of overhead
-    const decoder = mapYamlToLosslessDecoder<DecoderDocument>(values.rawDecoder);
+    const decoder = mapYamlToLosslessObject<DecoderDocument>(values.rawDecoder);
 
     if (!decoder.name) {
       errors.name = 'Decoder name is required';
@@ -248,7 +248,7 @@ export const DecoderFormPage: React.FC<DecoderFormPageProps> = (props) => {
           validate={validateForm}
           onSubmit={(values, { setSubmitting }) => {
             setSubmitting(false);
-            handleOnClick(mapYamlToLosslessDecoder<DecoderDocument>(values.rawDecoder));
+            handleOnClick(mapYamlToLosslessObject<DecoderDocument>(values.rawDecoder));
           }}
         >
           {(props) => (

--- a/public/pages/Decoders/utils/constants.ts
+++ b/public/pages/Decoders/utils/constants.ts
@@ -9,6 +9,18 @@ const TEXT_SEARCH_FIELDS = ['document.metadata.title', 'document.metadata.descri
 
 const escapeWildcard = (str: string) => str.replace(/[*?]/g, '\\$&');
 
+export const decoderFormDefaultValue: string = `name: decoder/<name>/<version>
+enabled: true
+metadata:
+  title: Placeholder Decoder
+  description: This is a placeholder decoder. Please update the fields accordingly.
+  author: User
+  date: '${new Date().toISOString().split('T')[0]}'
+  modified: '${new Date().toISOString().split('T')[0]}'
+  references: []
+  documentation: ''
+  supports: []`;
+
 export const buildDecodersSearchQuery = (searchText: string) => {
   const trimmed = searchText.trim();
   if (!trimmed) {

--- a/public/pages/Filters/components/FilterDetailsFlyout.tsx
+++ b/public/pages/Filters/components/FilterDetailsFlyout.tsx
@@ -24,16 +24,28 @@ import { Metadata } from '../../../components/Utility/Metadata';
 import { EnabledHealth } from '../../../components/Utility/EnabledHealth';
 import { BadgeGroup } from '../../../components/Utility/BadgeGroup';
 import { DEFAULT_EMPTY_DATA } from '../../../utils/constants';
+import { mapFormToFilterResource, mapFilterToForm } from '../utils/mappers';
+import { dump } from 'js-yaml';
 
 interface FilterDetailsFlyoutProps {
   filter: FilterItem;
   onClose: () => void;
 }
 
-const editorType = {
-  visual: 'visual',
-  json: 'json',
-};
+const editorType = [
+  {
+    id: 'visual',
+    label: 'Visual',
+  },
+  {
+    id: 'yaml',
+    label: 'YAML',
+  },
+  {
+    id: 'json',
+    label: 'JSON',
+  },
+];
 
 /** Resolve author display: indexer sends string; legacy may send { name } */
 const getAuthorDisplay = (author: string | { name?: string } | undefined): string => {
@@ -43,7 +55,7 @@ const getAuthorDisplay = (author: string | { name?: string } | undefined): strin
 };
 
 export const FilterDetailsFlyout: React.FC<FilterDetailsFlyoutProps> = ({ filter, onClose }) => {
-  const [selectedEditorType, setSelectedEditorType] = useState(editorType.visual);
+  const [selectedView, setSelectedView] = useState(editorType[0].id);
 
   const document = filter.document ?? {
     id: '',
@@ -77,7 +89,7 @@ export const FilterDetailsFlyout: React.FC<FilterDetailsFlyoutProps> = ({ filter
     { label: 'References', value: references, type: 'url' },
   ];
 
-  const visualTab = (
+  const visualContent = (
     <EuiFlexGrid columns={2}>
       {fields.map(({ label, value, type = 'text' }) => (
         <EuiFlexItem key={label}>
@@ -87,11 +99,30 @@ export const FilterDetailsFlyout: React.FC<FilterDetailsFlyoutProps> = ({ filter
     </EuiFlexGrid>
   );
 
-  const jsonTab = (
-    <EuiCodeBlock language={editorType.json} isCopyable={true} paddingSize="m">
+  const jsonContent = (
+    <EuiCodeBlock language="json" isCopyable={true} paddingSize="m">
       {JSON.stringify(document, null, 2)}
     </EuiCodeBlock>
   );
+
+  const yamlContent = (
+    <EuiCodeBlock language="yaml" isCopyable={true}>
+      {dump(mapFormToFilterResource(mapFilterToForm(document)))}
+    </EuiCodeBlock>
+  );
+
+  const renderContent = () => {
+    if (!document) {
+      return null;
+    }
+    if (selectedView === 'yaml') {
+      return yamlContent;
+    }
+    if (selectedView === 'json') {
+      return jsonContent;
+    }
+    return visualContent;
+  };
 
   return (
     <EuiFlyout onClose={onClose} hideCloseButton ownFocus size="m">
@@ -121,12 +152,9 @@ export const FilterDetailsFlyout: React.FC<FilterDetailsFlyoutProps> = ({ filter
               <EuiButtonGroup
                 data-test-subj="change-editor-type"
                 legend="This is editor type selector"
-                options={[
-                  { id: editorType.visual, label: 'Visual' },
-                  { id: editorType.json, label: 'JSON' },
-                ]}
-                idSelected={selectedEditorType}
-                onChange={(id) => setSelectedEditorType(id)}
+                options={editorType}
+                idSelected={selectedView}
+                onChange={(id) => setSelectedView(id)}
               />
             </EuiFlexItem>
             <EuiFlexItem>
@@ -134,7 +162,7 @@ export const FilterDetailsFlyout: React.FC<FilterDetailsFlyoutProps> = ({ filter
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiSpacer size="xl" />
-          {selectedEditorType === editorType.visual ? visualTab : jsonTab}
+          {renderContent()}
         </EuiModalBody>
       </EuiFlyoutBody>
     </EuiFlyout>

--- a/public/pages/Filters/containers/FilterFormPage.tsx
+++ b/public/pages/Filters/containers/FilterFormPage.tsx
@@ -190,6 +190,7 @@ export const FilterFormPage: React.FC<FilterFormPageProps> = ({
             errors,
             touched,
             isSubmitting,
+            setValues,
             setFieldValue,
             setFieldTouched,
             handleSubmit: formikSubmit,
@@ -426,13 +427,9 @@ export const FilterFormPage: React.FC<FilterFormPageProps> = ({
                     )}
                     change={(yamlString) => {
                       setRawFilter(yamlString);
-                      try {
-                        const parsed = mapYamlToLosslessObject<any>(yamlString);
-                        const formValues = mapYamlToFilterForm(parsed);
-                        setValues(formValues);
-                      } catch {
-                        // YAML inválido, Formik mantiene el estado anterior
-                      }
+                      const parsed = mapYamlToLosslessObject<FilterFormModel>(yamlString);
+                      const formValues = mapYamlToFilterForm(parsed);
+                      setValues(formValues);
                     }}
                   />
                 )}

--- a/public/pages/Filters/containers/FilterFormPage.tsx
+++ b/public/pages/Filters/containers/FilterFormPage.tsx
@@ -43,6 +43,10 @@ import {
   mapFormToFilterResource,
 } from '../utils/mappers';
 import { FILTER_TYPE_OPTIONS } from '../utils/constants';
+import { dump } from 'js-yaml';
+import { EuiButtonGroup } from '@elastic/eui';
+import { YamlForm, YAML_TYPE, mapYamlToLosslessDecoder } from '../../../components/YamlForm';
+import { filterFormDefaultYaml, mapYamlToFilterForm } from '../utils/mappers';
 
 const FILTER_ACTION = {
   CREATE: 'create',
@@ -54,6 +58,11 @@ const actionLabels: Record<FilterAction, string> = {
   create: 'Create',
   edit: 'Edit',
 };
+
+const editorTypes = [
+  { id: 'visual', label: 'Visual Editor' },
+  { id: 'yaml', label: 'YAML Editor' },
+];
 
 type FilterFormPageProps = {
   notifications: NotificationsStart;
@@ -73,6 +82,8 @@ export const FilterFormPage: React.FC<FilterFormPageProps> = ({
   const [initialValue, setInitialValue] = useState<FilterFormModel>(filterFormDefaultValue);
   const [typePopoverOpen, setTypePopoverOpen] = useState(false);
   const { spaceFilter } = useSpaceSelector();
+  const [selectedEditorType, setSelectedEditorType] = useState('visual');
+  const [rawFilter, setRawFilter] = useState<string>(filterFormDefaultYaml);
 
   // load existing filter when editing
   useEffect(() => {
@@ -197,187 +208,222 @@ export const FilterFormPage: React.FC<FilterFormPageProps> = ({
                   <EuiSpacer />
                 </PageHeader>
 
-                <EuiCompressedFormRow
-                  label={'Name'}
-                  fullWidth
-                  isInvalid={!!errors.name && touched.name}
-                  error={errors.name}
-                  helpText={
-                    !(errors.name && touched.name)
-                      ? 'Must follow the pattern filter/<name>/<version> (e.g. filter/prefilter/0)'
-                      : undefined
-                  }
-                >
-                  <EuiCompressedFieldText
-                    placeholder="filter/prefilter/0"
-                    value={values.name}
-                    onChange={(e) => setFieldValue('name', e.target.value)}
-                    onBlur={() => setFieldTouched('name')}
-                    isInvalid={!!errors.name && touched.name}
-                  />
-                </EuiCompressedFormRow>
-                <EuiSpacer size="m" />
-
-                <EuiCompressedFormRow
-                  label={
-                    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-                      <EuiFlexItem grow={false}>Type</EuiFlexItem>
-                      <EuiFlexItem grow={false}>
-                        <EuiPopover
-                          button={
-                            <EuiButtonIcon
-                              iconType="iInCircle"
-                              aria-label="Filter type information"
-                              onClick={() => setTypePopoverOpen(!typePopoverOpen)}
-                              color="primary"
-                              size="xs"
-                            />
-                          }
-                          isOpen={typePopoverOpen}
-                          closePopover={() => setTypePopoverOpen(false)}
-                          anchorPosition="downRight"
-                        >
-                          <div style={{ width: '300px' }}>
-                            <EuiText size="s">
-                              <strong>Filter types</strong>
-                            </EuiText>
-                            <EuiSpacer size="s" />
-                            <div style={{ paddingLeft: '16px' }}>
-                              <EuiText size="xs">
-                                <p>
-                                  <strong>Pre-filter:</strong> Processed before input is passed to the space decoder tree.
-                                </p>
-                              </EuiText>
-                              <EuiSpacer size="s" />
-                              <EuiText size="xs">
-                                <p>
-                                  <strong>Post-filter:</strong> Processed after event is normalized by the space decoder tree, and enriched.
-                                </p>
-                              </EuiText>
-                            </div>
-                          </div>
-                        </EuiPopover>
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  }
-                  fullWidth
-                  isInvalid={!!errors.type && touched.type}
-                  error={errors.type}
-                >
-                  <EuiCompressedSelect
-                    options={FILTER_TYPE_OPTIONS}
-                    value={values.type}
-                    onChange={(e) => setFieldValue('type', e.target.value)}
-                    onBlur={() => setFieldTouched('type')}
-                    isInvalid={!!errors.type && touched.type}
-                  />
-                </EuiCompressedFormRow>
-                <EuiSpacer size="m" />
-
-                <EuiCompressedFormRow
-                  label={'Check expression'}
-                  fullWidth
-                  isInvalid={!!errors.check && touched.check}
-                  error={errors.check}
-                  helpText="Expression evaluated to determine if the filter applies (e.g. $host.os.platform == 'ubuntu')"
-                >
-                  <EuiCompressedTextArea
-                    placeholder="$host.os.platform == 'ubuntu'"
-                    value={values.check}
-                    onChange={(e) => setFieldValue('check', e.target.value)}
-                    onBlur={() => setFieldTouched('check')}
-                    isInvalid={!!errors.check && touched.check}
-                    rows={3}
-                  />
-                </EuiCompressedFormRow>
-                <EuiSpacer size="m" />
-
-                <EuiCompressedFormRow label={'Enabled'} fullWidth>
-                  <EuiCompressedSwitch
-                    label={values.enabled ? 'Enabled' : 'Disabled'}
-                    checked={values.enabled}
-                    onChange={(e) => setFieldValue('enabled', e.target.checked)}
-                  />
-                </EuiCompressedFormRow>
-
-                <EuiSpacer size="l" />
-
-                <EuiCompressedFormRow
-                  label={'Author'}
-                  fullWidth
-                  isInvalid={!!errors.author && touched.author}
-                  error={errors.author}
-                >
-                  <EuiCompressedFieldText
-                    placeholder="Enter author name"
-                    value={values.author}
-                    onChange={(e) => setFieldValue('author', e.target.value)}
-                    onBlur={() => setFieldTouched('author')}
-                    isInvalid={!!errors.author && touched.author}
-                  />
-                </EuiCompressedFormRow>
-                
-                <EuiSpacer size="m" />
-
-                <EuiCompressedFormRow
-                  label={
-                    <>
-                      {'Description - '}
-                      <em>optional</em>
-                    </>
-                  }
-                  fullWidth
-                >
-                  <EuiCompressedTextArea
-                    placeholder="Brief description of what this filter does"
-                    value={values.description}
-                    onChange={(e) => setFieldValue('description', e.target.value)}
-                    rows={2}
-                  />
-                </EuiCompressedFormRow>
-                <EuiSpacer size="m" />
-
-                <EuiCompressedFormRow
-                  label={
-                    <>
-                      {'Documentation - '}
-                      <em>optional</em>
-                    </>
-                  }
-                  fullWidth
-                >
-                  <EuiCompressedFieldText
-                    placeholder="Enter documentation URL"
-                    value={values.documentation}
-                    onChange={(e) => setFieldValue('documentation', e.target.value)}
-                  />
-                </EuiCompressedFormRow>
-                <EuiSpacer size="m" />
-
-                <FormFieldArray
-                  label={
-                    <>
-                      {'References - '}
-                      <em>optional</em>
-                    </>
-                  }
-                  values={values.references}
-                  placeholder="https://example.com/reference"
-                  addButtonLabel="Add reference"
-                  onChange={(references) => setFieldValue('references', references)}
+                <EuiButtonGroup
+                  legend="Editor type selector"
+                  options={editorTypes}
+                  idSelected={selectedEditorType}
+                  onChange={(id) => {
+                    if (id === 'yaml') {
+                      setRawFilter(dump(mapFormToFilterResource(values)));
+                    }
+                    setSelectedEditorType(id);
+                  }}
                 />
+                <EuiSpacer size="xl" />
 
-                <FormFieldArray
-                  label={
-                    <>
-                      {'Supports - '}
-                      <em>optional</em>
-                    </>
-                  }
-                  values={values.supports}
-                  addButtonLabel="Add support"
-                  onChange={(supports) => setFieldValue('supports', supports)}
-                />
+                {selectedEditorType === 'visual' && (
+                  <>
+                    <EuiCompressedFormRow
+                      label={'Name'}
+                      fullWidth
+                      isInvalid={!!errors.name && touched.name}
+                      error={errors.name}
+                      helpText={
+                        !(errors.name && touched.name)
+                          ? 'Must follow the pattern filter/<name>/<version> (e.g. filter/prefilter/0)'
+                          : undefined
+                      }
+                    >
+                      <EuiCompressedFieldText
+                        placeholder="filter/prefilter/0"
+                        value={values.name}
+                        onChange={(e) => setFieldValue('name', e.target.value)}
+                        onBlur={() => setFieldTouched('name')}
+                        isInvalid={!!errors.name && touched.name}
+                      />
+                    </EuiCompressedFormRow>
+                    <EuiSpacer size="m" />
+
+                    <EuiCompressedFormRow
+                      label={
+                        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                          <EuiFlexItem grow={false}>Type</EuiFlexItem>
+                          <EuiFlexItem grow={false}>
+                            <EuiPopover
+                              button={
+                                <EuiButtonIcon
+                                  iconType="iInCircle"
+                                  aria-label="Filter type information"
+                                  onClick={() => setTypePopoverOpen(!typePopoverOpen)}
+                                  color="primary"
+                                  size="xs"
+                                />
+                              }
+                              isOpen={typePopoverOpen}
+                              closePopover={() => setTypePopoverOpen(false)}
+                              anchorPosition="downRight"
+                            >
+                              <div style={{ width: '300px' }}>
+                                <EuiText size="s">
+                                  <strong>Filter types</strong>
+                                </EuiText>
+                                <EuiSpacer size="s" />
+                                <div style={{ paddingLeft: '16px' }}>
+                                  <EuiText size="xs">
+                                    <p>
+                                      <strong>Pre-filter:</strong> Processed before input is passed to the space decoder tree.
+                                    </p>
+                                  </EuiText>
+                                  <EuiSpacer size="s" />
+                                  <EuiText size="xs">
+                                    <p>
+                                      <strong>Post-filter:</strong> Processed after event is normalized by the space decoder tree, and enriched.
+                                    </p>
+                                  </EuiText>
+                                </div>
+                              </div>
+                            </EuiPopover>
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      }
+                      fullWidth
+                      isInvalid={!!errors.type && touched.type}
+                      error={errors.type}
+                    >
+                      <EuiCompressedSelect
+                        options={FILTER_TYPE_OPTIONS}
+                        value={values.type}
+                        onChange={(e) => setFieldValue('type', e.target.value)}
+                        onBlur={() => setFieldTouched('type')}
+                        isInvalid={!!errors.type && touched.type}
+                      />
+                    </EuiCompressedFormRow>
+                    <EuiSpacer size="m" />
+
+                    <EuiCompressedFormRow
+                      label={'Check expression'}
+                      fullWidth
+                      isInvalid={!!errors.check && touched.check}
+                      error={errors.check}
+                      helpText="Expression evaluated to determine if the filter applies (e.g. $host.os.platform == 'ubuntu')"
+                    >
+                      <EuiCompressedTextArea
+                        placeholder="$host.os.platform == 'ubuntu'"
+                        value={values.check}
+                        onChange={(e) => setFieldValue('check', e.target.value)}
+                        onBlur={() => setFieldTouched('check')}
+                        isInvalid={!!errors.check && touched.check}
+                        rows={3}
+                      />
+                    </EuiCompressedFormRow>
+                    <EuiSpacer size="m" />
+
+                    <EuiCompressedFormRow label={'Enabled'} fullWidth>
+                      <EuiCompressedSwitch
+                        label={values.enabled ? 'Enabled' : 'Disabled'}
+                        checked={values.enabled}
+                        onChange={(e) => setFieldValue('enabled', e.target.checked)}
+                      />
+                    </EuiCompressedFormRow>
+
+                    <EuiSpacer size="l" />
+
+                    <EuiCompressedFormRow
+                      label={'Author'}
+                      fullWidth
+                      isInvalid={!!errors.author && touched.author}
+                      error={errors.author}
+                    >
+                      <EuiCompressedFieldText
+                        placeholder="Enter author name"
+                        value={values.author}
+                        onChange={(e) => setFieldValue('author', e.target.value)}
+                        onBlur={() => setFieldTouched('author')}
+                        isInvalid={!!errors.author && touched.author}
+                      />
+                    </EuiCompressedFormRow>
+                    
+                    <EuiSpacer size="m" />
+
+                    <EuiCompressedFormRow
+                      label={
+                        <>
+                          {'Description - '}
+                          <em>optional</em>
+                        </>
+                      }
+                      fullWidth
+                    >
+                      <EuiCompressedTextArea
+                        placeholder="Brief description of what this filter does"
+                        value={values.description}
+                        onChange={(e) => setFieldValue('description', e.target.value)}
+                        rows={2}
+                      />
+                    </EuiCompressedFormRow>
+                    <EuiSpacer size="m" />
+
+                    <EuiCompressedFormRow
+                      label={
+                        <>
+                          {'Documentation - '}
+                          <em>optional</em>
+                        </>
+                      }
+                      fullWidth
+                    >
+                      <EuiCompressedFieldText
+                        placeholder="Enter documentation URL"
+                        value={values.documentation}
+                        onChange={(e) => setFieldValue('documentation', e.target.value)}
+                      />
+                    </EuiCompressedFormRow>
+                    <EuiSpacer size="m" />
+
+                    <FormFieldArray
+                      label={
+                        <>
+                          {'References - '}
+                          <em>optional</em>
+                        </>
+                      }
+                      values={values.references}
+                      placeholder="https://example.com/reference"
+                      addButtonLabel="Add reference"
+                      onChange={(references) => setFieldValue('references', references)}
+                    />
+
+                    <FormFieldArray
+                      label={
+                        <>
+                          {'Supports - '}
+                          <em>optional</em>
+                        </>
+                      }
+                      values={values.supports}
+                      addButtonLabel="Add support"
+                      onChange={(supports) => setFieldValue('supports', supports)}
+                    />
+                  </>
+                )}
+                {selectedEditorType === 'yaml' && (
+                  <YamlForm
+                    type={YAML_TYPE.FILTER}
+                    value={rawFilter}
+                    isInvalid={Object.keys(errors).length > 0}
+                    errors={Object.keys(errors).map((key) => (errors as Record<string, string>)[key])}
+                    change={(yamlString) => {
+                      setRawFilter(yamlString);
+                      try {
+                        const parsed = mapYamlToLosslessDecoder<any>(yamlString);
+                        const formValues = mapYamlToFilterForm(parsed);
+                        setValues(formValues);
+                      } catch {
+                        // YAML inválido, Formik mantiene el estado anterior
+                      }
+                    }}
+                  />
+                )}
               </EuiPanel>
 
               <EuiSpacer size="xl" />

--- a/public/pages/Filters/containers/FilterFormPage.tsx
+++ b/public/pages/Filters/containers/FilterFormPage.tsx
@@ -45,7 +45,7 @@ import {
 import { FILTER_TYPE_OPTIONS } from '../utils/constants';
 import { dump } from 'js-yaml';
 import { EuiButtonGroup } from '@elastic/eui';
-import { YamlForm, YAML_TYPE, mapYamlToLosslessDecoder } from '../../../components/YamlForm';
+import { YamlForm, YAML_TYPE, mapYamlToLosslessObject } from '../../../components/YamlForm';
 import { filterFormDefaultYaml, mapYamlToFilterForm } from '../utils/mappers';
 
 const FILTER_ACTION = {
@@ -201,9 +201,17 @@ export const FilterFormPage: React.FC<FilterFormPageProps> = ({
                     <h1>{actionLabels[action]} filter</h1>
                   </EuiText>
                   <EuiText size="s" color="subdued">
-                    {action === FILTER_ACTION.CREATE
-                      ? <>Create a new event filter in the <strong>{spaceFilter || 'draft'}</strong> space.</>
-                      : <>Edit the filter configuration in the <strong>{spaceFilter || 'draft'}</strong> space.</>}
+                    {action === FILTER_ACTION.CREATE ? (
+                      <>
+                        Create a new event filter in the <strong>{spaceFilter || 'draft'}</strong>{' '}
+                        space.
+                      </>
+                    ) : (
+                      <>
+                        Edit the filter configuration in the{' '}
+                        <strong>{spaceFilter || 'draft'}</strong> space.
+                      </>
+                    )}
                   </EuiText>
                   <EuiSpacer />
                 </PageHeader>
@@ -271,13 +279,15 @@ export const FilterFormPage: React.FC<FilterFormPageProps> = ({
                                 <div style={{ paddingLeft: '16px' }}>
                                   <EuiText size="xs">
                                     <p>
-                                      <strong>Pre-filter:</strong> Processed before input is passed to the space decoder tree.
+                                      <strong>Pre-filter:</strong> Processed before input is passed
+                                      to the space decoder tree.
                                     </p>
                                   </EuiText>
                                   <EuiSpacer size="s" />
                                   <EuiText size="xs">
                                     <p>
-                                      <strong>Post-filter:</strong> Processed after event is normalized by the space decoder tree, and enriched.
+                                      <strong>Post-filter:</strong> Processed after event is
+                                      normalized by the space decoder tree, and enriched.
                                     </p>
                                   </EuiText>
                                 </div>
@@ -342,7 +352,7 @@ export const FilterFormPage: React.FC<FilterFormPageProps> = ({
                         isInvalid={!!errors.author && touched.author}
                       />
                     </EuiCompressedFormRow>
-                    
+
                     <EuiSpacer size="m" />
 
                     <EuiCompressedFormRow
@@ -411,11 +421,13 @@ export const FilterFormPage: React.FC<FilterFormPageProps> = ({
                     type={YAML_TYPE.FILTER}
                     value={rawFilter}
                     isInvalid={Object.keys(errors).length > 0}
-                    errors={Object.keys(errors).map((key) => (errors as Record<string, string>)[key])}
+                    errors={Object.keys(errors).map(
+                      (key) => (errors as Record<string, string>)[key]
+                    )}
                     change={(yamlString) => {
                       setRawFilter(yamlString);
                       try {
-                        const parsed = mapYamlToLosslessDecoder<any>(yamlString);
+                        const parsed = mapYamlToLosslessObject<any>(yamlString);
                         const formValues = mapYamlToFilterForm(parsed);
                         setValues(formValues);
                       } catch {

--- a/public/pages/Filters/containers/FilterFormPage.tsx
+++ b/public/pages/Filters/containers/FilterFormPage.tsx
@@ -25,7 +25,6 @@ import { FormFieldArray } from '../../../components/FormFieldArray';
 import { Form, Formik, FormikErrors } from 'formik';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { RouteComponentProps } from 'react-router-dom';
-import FormFieldHeader from '../../../components/FormFieldHeader';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
 import { DataStore } from '../../../store/DataStore';
 import { BREADCRUMBS, ROUTES } from '../../../utils/constants';
@@ -46,7 +45,7 @@ import { FILTER_TYPE_OPTIONS } from '../utils/constants';
 import { dump } from 'js-yaml';
 import { EuiButtonGroup } from '@elastic/eui';
 import { YamlForm, YAML_TYPE, mapYamlToLosslessObject } from '../../../components/YamlForm';
-import { filterFormDefaultYaml, mapYamlToFilterForm } from '../utils/mappers';
+import { mapYamlToFilterForm } from '../utils/mappers';
 
 const FILTER_ACTION = {
   CREATE: 'create',
@@ -83,7 +82,7 @@ export const FilterFormPage: React.FC<FilterFormPageProps> = ({
   const [typePopoverOpen, setTypePopoverOpen] = useState(false);
   const { spaceFilter } = useSpaceSelector();
   const [selectedEditorType, setSelectedEditorType] = useState('visual');
-  const [rawFilter, setRawFilter] = useState<string>(filterFormDefaultYaml);
+  const [rawFilter, setRawFilter] = useState<string>();
 
   // load existing filter when editing
   useEffect(() => {

--- a/public/pages/Filters/utils/mappers.ts
+++ b/public/pages/Filters/utils/mappers.ts
@@ -4,6 +4,7 @@
  */
 
 import { FilterDocument, FilterResource } from '../../../../types/Filters';
+import { dump } from 'js-yaml';
 
 export interface FilterFormModel {
   name: string;
@@ -27,6 +28,42 @@ export const filterFormDefaultValue: FilterFormModel = {
   documentation: '',
   references: [],
   supports: [],
+};
+
+
+export const filterFormDefaultYaml: string = (() => {
+  const now = new Date().toISOString().split('T')[0];
+  return dump({
+    name: 'filter/<name>/<version>',
+    type: 'pre-filter',
+    check: '',
+    enabled: true,
+    metadata: {
+      title: '',
+      author: '',
+      date: now,
+      modified: now,
+      description: '',
+      documentation: '',
+      references: [],
+      supports: [],
+    },
+  });
+})();
+
+export const mapYamlToFilterForm = (yamlObj: any): FilterFormModel => {
+  const author = yamlObj?.metadata?.author;
+  return {
+    name: yamlObj?.name ?? '',
+    type: yamlObj?.type ?? 'pre-filter',
+    check: yamlObj?.check ?? '',
+    enabled: yamlObj?.enabled ?? true,
+    author: typeof author === 'string' ? author : author?.name ?? '',
+    description: yamlObj?.metadata?.description ?? '',
+    documentation: yamlObj?.metadata?.documentation ?? '',
+    references: yamlObj?.metadata?.references ?? [],
+    supports: yamlObj?.metadata?.supports ?? [],
+  };
 };
 
 export const mapFilterToForm = (document: FilterDocument): FilterFormModel => {

--- a/public/pages/Filters/utils/mappers.ts
+++ b/public/pages/Filters/utils/mappers.ts
@@ -4,7 +4,6 @@
  */
 
 import { FilterDocument, FilterResource } from '../../../../types/Filters';
-import { dump } from 'js-yaml';
 
 export interface FilterFormModel {
   name: string;
@@ -29,23 +28,6 @@ export const filterFormDefaultValue: FilterFormModel = {
   references: [],
   supports: [],
 };
-
-export const filterFormDefaultYaml: string = (() => {
-  const now = new Date().toISOString().split('T')[0];
-  return dump({
-    name: 'filter/<name>/<version>',
-    type: 'pre-filter',
-    check: '',
-    enabled: true,
-    metadata: {
-      author: '',
-      description: '',
-      documentation: '',
-      references: [],
-      supports: [],
-    },
-  });
-})();
 
 export const mapYamlToFilterForm = (yamlObj: any): FilterFormModel => {
   const author = yamlObj?.metadata?.author;

--- a/public/pages/Filters/utils/mappers.ts
+++ b/public/pages/Filters/utils/mappers.ts
@@ -30,7 +30,6 @@ export const filterFormDefaultValue: FilterFormModel = {
   supports: [],
 };
 
-
 export const filterFormDefaultYaml: string = (() => {
   const now = new Date().toISOString().split('T')[0];
   return dump({
@@ -39,10 +38,7 @@ export const filterFormDefaultYaml: string = (() => {
     check: '',
     enabled: true,
     metadata: {
-      title: '',
       author: '',
-      date: now,
-      modified: now,
       description: '',
       documentation: '',
       references: [],

--- a/public/services/DecodersService.ts
+++ b/public/services/DecodersService.ts
@@ -7,7 +7,7 @@ import { HttpSetup } from 'opensearch-dashboards/public';
 import { API } from '../../server/utils/constants';
 import { ServerResponse } from '../../server/models/types';
 import { CUDDecoderResponse, GetDecoderResponse, SearchDecodersResponse } from '../../types';
-import { parse as LosslessParse, stringify as LosslessStringify } from 'lossless-json';
+import { stringify as LosslessStringify } from 'lossless-json';
 
 export default class DecodersService {
   private readonly httpClient: HttpSetup;
@@ -60,25 +60,21 @@ export default class DecodersService {
     }
   };
 
-getDecoder = async (
-  decoderId: string,
-  space: string
-): Promise<ServerResponse<GetDecoderResponse>> => {
-  try {
-    const url = `${this.baseUrl}/${decoderId}`;
-    const normalizedSpace = this.normalizeSpace(space);
-    const query = normalizedSpace ? `?space=${normalizedSpace}` : '';
-    const response = await fetch(`${url}${query}`, {
-      headers: {
-        'osd-xsrf': 'true',
-      },
-    });
-    const text = await response.text();
-    return LosslessParse(text) as ServerResponse<GetDecoderResponse>;
-  } catch (error: any) {
-    return { ok: false, error: this.parseHttpError(error) };
-  }
-};
+  getDecoder = async (
+    decoderId: string,
+    space: string
+  ): Promise<ServerResponse<GetDecoderResponse>> => {
+    try {
+      const url = `${this.baseUrl}/${decoderId}`;
+      const normalizedSpace = this.normalizeSpace(space);
+      const query = normalizedSpace ? { space: normalizedSpace } : {};
+      return (await this.httpClient.get(url, {
+        query,
+      })) as ServerResponse<GetDecoderResponse>;
+    } catch (error: any) {
+      return { ok: false, error: this.parseHttpError(error) };
+    }
+  };
 
   createDecoder = async (body: {
     document: any;


### PR DESCRIPTION
### Description
This PR implements an additional way to create a filter by using a YAML code editor .

### Issues Resolved
[#220 ](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/220)

### Evidence
[yaml_filters.webm](https://github.com/user-attachments/assets/6633162c-e6d7-4921-93aa-0d7f8dc70b5a)

### Tests

- Navigate to Security Analytics > Overview and click on Filter and then access to the Create tab.
- Verify that data synchronizes correctly when switching back and forth between the YAML Editor and the Visual Editor.
- Create the filter and verify that the YAML view renders correctly.
- Edit the created filter using the YAML Editor and ensure changes are saved properly.


### Check List
- [X] Commits are signed per the DCO using --signoff