### PR TITLE
add selective promote with dependency-aware warnings

### DIFF
--- a/public/hooks/usePromoteInconsistencies.ts
+++ b/public/hooks/usePromoteInconsistencies.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Wazuh Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { useMemo } from 'react';
+import { GetPromoteBySpaceResponse, PromoteChangeGroup } from '../../types';
+import { MANDATORY_PROMOTE_ENTITIES, SelectedMap } from './usePromoteSelection';
+
+/**
+ * Bidirectional dependency map used to detect risky partial selections.
+ * See PromoteIntegration container for the semantic model.
+ */
+export const PROMOTE_DEPENDENCY_CHAIN: Record<string, readonly string[]> = {
+  integrations: ['decoders', 'kvdbs', 'filters', 'rules'],
+  decoders: ['integrations'],
+  kvdbs: ['integrations'],
+  filters: ['integrations', 'decoders'],
+  rules: ['integrations', 'decoders', 'kvdbs'],
+};
+
+export type IntegrationChildrenMap = Record<
+  string,
+  { title: string; decoders: string[]; rules: string[]; kvdbs: string[] }
+>;
+
+export interface PromoteInconsistency {
+  parent: string;
+  parentTitle?: string;
+  dep: string;
+  missingNames: string[];
+}
+
+const getName = (
+  promoteData: GetPromoteBySpaceResponse['response'],
+  entity: string,
+  id: string
+) => {
+  const strippedId = id.replace(/^\w_/, '');
+  const available = promoteData.available_promotions?.[entity as PromoteChangeGroup];
+  return available?.[id] ?? available?.[strippedId] ?? id;
+};
+
+/**
+ * Detects items whose promotion would leave broken references in the target
+ * space. Uses the integration→children map when available (precise mode) and
+ * falls back to the coarse dependency chain for groups without a mapping
+ * (e.g. filters).
+ */
+export function usePromoteInconsistencies(
+  promoteData: GetPromoteBySpaceResponse['response'],
+  selected: SelectedMap,
+  integrationChildren: IntegrationChildrenMap
+): PromoteInconsistency[] {
+  return useMemo(() => {
+    const out: PromoteInconsistency[] = [];
+
+    const integrationsInDiff = new Set(
+      (promoteData.promote?.changes?.integrations ?? []).map((i) => i.id)
+    );
+    const selectedIntegrations = selected.integrations ?? new Set<string>();
+
+    // Forward: each selected integration's children that are in the diff
+    // but not selected.
+    for (const intId of selectedIntegrations) {
+      const children = integrationChildren?.[intId];
+      if (!children) continue;
+      const childGroups: Array<{ group: 'decoders' | 'rules' | 'kvdbs'; ids: string[] }> = [
+        { group: 'decoders', ids: children.decoders },
+        { group: 'rules', ids: children.rules },
+        { group: 'kvdbs', ids: children.kvdbs },
+      ];
+      for (const { group, ids } of childGroups) {
+        const diffIds = new Set(
+          (promoteData.promote?.changes?.[group as PromoteChangeGroup] ?? []).map((i) => i.id)
+        );
+        const selectedSet = selected[group] ?? new Set<string>();
+        const missingInDiff = ids.filter((id) => diffIds.has(id) && !selectedSet.has(id));
+        if (missingInDiff.length > 0) {
+          out.push({
+            parent: 'integrations',
+            parentTitle: children.title,
+            dep: group,
+            missingNames: missingInDiff.map((id) => getName(promoteData, group, id)),
+          });
+        }
+      }
+    }
+
+    // Reverse: selected children whose parent integration is in the diff but
+    // not selected.
+    const childToIntegration: Record<string, Record<string, { id: string; title: string }>> = {
+      decoders: {},
+      rules: {},
+      kvdbs: {},
+    };
+    for (const [intId, meta] of Object.entries(integrationChildren ?? {})) {
+      for (const dId of meta.decoders)
+        childToIntegration.decoders[dId] = { id: intId, title: meta.title };
+      for (const rId of meta.rules)
+        childToIntegration.rules[rId] = { id: intId, title: meta.title };
+      for (const kId of meta.kvdbs)
+        childToIntegration.kvdbs[kId] = { id: intId, title: meta.title };
+    }
+    const orphanParents: Record<string, Set<string>> = {};
+    for (const group of ['decoders', 'rules', 'kvdbs'] as const) {
+      const selectedSet = selected[group] ?? new Set<string>();
+      for (const childId of selectedSet) {
+        const parent = childToIntegration[group][childId];
+        if (!parent) continue;
+        if (integrationsInDiff.has(parent.id) && !selectedIntegrations.has(parent.id)) {
+          if (!orphanParents[parent.id]) orphanParents[parent.id] = new Set();
+          orphanParents[parent.id].add(parent.title);
+        }
+      }
+    }
+    for (const [, titles] of Object.entries(orphanParents)) {
+      out.push({
+        parent: 'decoders/rules/kvdbs',
+        parentTitle: 'selected children',
+        dep: 'integrations',
+        missingNames: Array.from(titles),
+      });
+    }
+
+    // Coarse fallback for groups with no integration mapping (filters don't
+    // live under integration documents).
+    for (const parent of Object.keys(PROMOTE_DEPENDENCY_CHAIN)) {
+      if (MANDATORY_PROMOTE_ENTITIES.has(parent)) continue;
+      if (parent !== 'filters') continue; // precise path handles the rest
+      const parentSelected = (selected[parent]?.size ?? 0) > 0;
+      if (!parentSelected) continue;
+      for (const dep of PROMOTE_DEPENDENCY_CHAIN[parent]) {
+        const depItems = promoteData.promote?.changes?.[dep as PromoteChangeGroup] ?? [];
+        if (depItems.length === 0) continue;
+        const depSelected = selected[dep] ?? new Set<string>();
+        const missing = depItems.filter((item) => !depSelected.has(item.id));
+        if (missing.length > 0) {
+          out.push({
+            parent,
+            dep,
+            missingNames: missing.map((item) => getName(promoteData, dep, item.id)),
+          });
+        }
+      }
+    }
+
+    return out;
+  }, [selected, promoteData, integrationChildren]);
+}

--- a/public/hooks/usePromoteSelection.ts
+++ b/public/hooks/usePromoteSelection.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Wazuh Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { useMemo, useState } from 'react';
+import { PROMOTE_ENTITIES_ORDER } from '../utils/constants';
+import { GetPromoteBySpaceResponse, PromoteChangeGroup, PromoteChanges } from '../../types';
+
+export type SelectedMap = Record<string, Set<string>>;
+
+/**
+ * Entities that are promoted unconditionally (no checkbox in the UI). Policy
+ * represents the space itself and always travels with the selected changes.
+ */
+export const MANDATORY_PROMOTE_ENTITIES: ReadonlySet<string> = new Set(['policy']);
+
+/**
+ * Manages the set of items the user has chosen to promote. Encapsulates all
+ * toggle logic (per-item, per-group, global select/deselect) and derives the
+ * PromoteChanges payload to send to the backend.
+ */
+export function usePromoteSelection(promoteData: GetPromoteBySpaceResponse['response']) {
+  const [selected, setSelected] = useState<SelectedMap>(() => {
+    const init: SelectedMap = {};
+    PROMOTE_ENTITIES_ORDER.forEach((entity) => {
+      const items = promoteData.promote?.changes?.[entity as PromoteChangeGroup] ?? [];
+      init[entity] = new Set(items.map((item) => item.id));
+    });
+    return init;
+  });
+
+  const toggleItem = (entity: PromoteChangeGroup, id: string) => {
+    if (MANDATORY_PROMOTE_ENTITIES.has(entity)) return;
+    setSelected((prev) => {
+      const nextSet = new Set(prev[entity] ?? []);
+      if (nextSet.has(id)) {
+        nextSet.delete(id);
+      } else {
+        nextSet.add(id);
+      }
+      return { ...prev, [entity]: nextSet };
+    });
+  };
+
+  const toggleAll = (entity: PromoteChangeGroup) => {
+    if (MANDATORY_PROMOTE_ENTITIES.has(entity)) return;
+    setSelected((prev) => {
+      const items = promoteData.promote?.changes?.[entity as PromoteChangeGroup] ?? [];
+      const prevSet = prev[entity] ?? new Set<string>();
+      const allSelected = items.length > 0 && items.every((item) => prevSet.has(item.id));
+      const nextSet = allSelected ? new Set<string>() : new Set(items.map((item) => item.id));
+      return { ...prev, [entity]: nextSet };
+    });
+  };
+
+  const selectAllGlobal = () => {
+    setSelected((prev) => {
+      const next: SelectedMap = { ...prev };
+      PROMOTE_ENTITIES_ORDER.forEach((entity) => {
+        if (MANDATORY_PROMOTE_ENTITIES.has(entity)) return;
+        const items = promoteData.promote?.changes?.[entity as PromoteChangeGroup] ?? [];
+        next[entity] = new Set(items.map((item) => item.id));
+      });
+      return next;
+    });
+  };
+
+  const deselectAllGlobal = () => {
+    setSelected((prev) => {
+      const next: SelectedMap = { ...prev };
+      PROMOTE_ENTITIES_ORDER.forEach((entity) => {
+        if (MANDATORY_PROMOTE_ENTITIES.has(entity)) return;
+        next[entity] = new Set<string>();
+      });
+      return next;
+    });
+  };
+
+  const selectedChanges = useMemo(() => {
+    const out = {} as PromoteChanges;
+    PROMOTE_ENTITIES_ORDER.forEach((entity) => {
+      const items = promoteData.promote?.changes?.[entity as PromoteChangeGroup] ?? [];
+      const sel = selected[entity] ?? new Set<string>();
+      (out as any)[entity] = items.filter((item) => sel.has(item.id));
+    });
+    return out;
+  }, [selected, promoteData]);
+
+  const selectedPromoteData = useMemo(
+    () => ({
+      ...promoteData,
+      promote: { ...promoteData.promote, changes: selectedChanges },
+    }),
+    [promoteData, selectedChanges]
+  );
+
+  const hasPromotions = Object.values(promoteData.promote.changes).some(
+    (items) => items.length > 0
+  );
+
+  // Policy alone doesn't enable the Promote button — the user must have
+  // selected at least one item from a non-mandatory group.
+  const hasSelected = PROMOTE_ENTITIES_ORDER.some(
+    (entity) =>
+      !MANDATORY_PROMOTE_ENTITIES.has(entity) && ((selectedChanges as any)[entity]?.length ?? 0) > 0
+  );
+
+  return {
+    selected,
+    toggleItem,
+    toggleAll,
+    selectAllGlobal,
+    deselectAllGlobal,
+    selectedChanges,
+    selectedPromoteData,
+    hasPromotions,
+    hasSelected,
+  };
+}

--- a/public/hooks/usePromoteSubmit.ts
+++ b/public/hooks/usePromoteSubmit.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Wazuh Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { useCallback } from 'react';
+import { NotificationsStart } from 'opensearch-dashboards/public';
+import { DataStore } from '../store/DataStore';
+import { errorNotificationToast, successNotificationToast } from '../utils/helpers';
+import { PromoteChanges, PromoteSpaces } from '../../types';
+
+interface UsePromoteSubmitOptions {
+  space: PromoteSpaces;
+  notifications: NotificationsStart;
+  onSuccess: () => void;
+}
+
+/**
+ * Returns an async submitter that calls the promote API with the given
+ * changes, surfaces the engine's error message as a toast on failure, and
+ * calls `onSuccess` on success. Keeps the container free of DataStore /
+ * notifications wiring.
+ */
+export function usePromoteSubmit({ space, notifications, onSuccess }: UsePromoteSubmitOptions) {
+  return useCallback(
+    async (changes: PromoteChanges): Promise<boolean> => {
+      try {
+        const result = await DataStore.integrations.promoteIntegration({ space, changes });
+        if (result.ok) {
+          successNotificationToast(notifications, 'promoted', `[${space}] space`);
+          onSuccess();
+        }
+        // On failure the store already fired an error toast with the engine
+        // message; nothing else to do here.
+        return result.ok;
+      } catch (error: any) {
+        // OSD http client throws on non-2xx; the engine error is usually in
+        // error.body.error (not body.message). Check both shapes.
+        const message =
+          (typeof error?.body === 'string' && error.body) ||
+          error?.body?.error ||
+          error?.body?.message ||
+          error?.message ||
+          'Unknown error';
+        errorNotificationToast(notifications, 'promote', 'integration', message);
+        return false;
+      }
+    },
+    [space, notifications, onSuccess]
+  );
+}

--- a/public/pages/Integrations/components/InconsistenciesCallout.tsx
+++ b/public/pages/Integrations/components/InconsistenciesCallout.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Wazuh Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import React from 'react';
+import { EuiCallOut, EuiSpacer, EuiText } from '@elastic/eui';
+import { PROMOTE_ENTITIES_LABELS } from '../../../utils/constants';
+import { PromoteInconsistency } from '../../../hooks/usePromoteInconsistencies';
+
+const formatMissingNames = (names: string[]) => {
+  const preview = names.slice(0, 5).join(', ');
+  const extra = names.length > 5 ? `, +${names.length - 5} more` : '';
+  return `${preview}${extra}.`;
+};
+
+const InconsistencyItem: React.FC<{ item: PromoteInconsistency }> = ({ item }) => {
+  const { parent, parentTitle, dep, missingNames } = item;
+  const depLabel = PROMOTE_ENTITIES_LABELS[dep] || dep;
+  const names = formatMissingNames(missingNames);
+
+  if (parent === 'integrations' && parentTitle) {
+    return (
+      <>
+        Integration <b>{parentTitle}</b> bundles <b>{missingNames.length}</b> <b>{depLabel}</b> not
+        selected: {names}
+      </>
+    );
+  }
+  if (parent === 'decoders/rules/kvdbs') {
+    return <>Selected items whose parent integration is not selected: {names}</>;
+  }
+  return (
+    <>
+      <b>{PROMOTE_ENTITIES_LABELS[parent] || parent}</b> selected, but <b>{missingNames.length}</b>{' '}
+      <b>{depLabel}</b> not selected: {names}
+    </>
+  );
+};
+
+export const InconsistenciesCallout: React.FC<{
+  inconsistencies: PromoteInconsistency[];
+}> = ({ inconsistencies }) => {
+  if (inconsistencies.length === 0) {
+    return null;
+  }
+  return (
+    <>
+      <EuiSpacer size="m" />
+      <EuiCallOut
+        size="s"
+        color="warning"
+        iconType="alert"
+        title="Your selection has potential broken references"
+      >
+        <ul>
+          {inconsistencies.map((item, i) => (
+            <li key={`${item.parent}-${item.dep}-${item.parentTitle ?? ''}-${i}`}>
+              <InconsistencyItem item={item} />
+            </li>
+          ))}
+        </ul>
+        <EuiText size="xs">
+          Promotion may fail or leave the target space with inconsistencies.
+        </EuiText>
+      </EuiCallOut>
+      <EuiSpacer size="m" />
+    </>
+  );
+};

--- a/public/pages/Integrations/components/PromoteModal.tsx
+++ b/public/pages/Integrations/components/PromoteModal.tsx
@@ -18,12 +18,15 @@ import { GetPromoteBySpaceResponse, PromoteChangeGroup, PromoteSpaces } from '..
 import { getNextSpace } from '../../../../common/helpers';
 import { PromoteChangeDiff } from './PromoteChangeDiff';
 import { PROMOTE_ENTITIES_LABELS, PROMOTE_ENTITIES_ORDER } from '../../../utils/constants';
+import { InconsistenciesCallout } from './InconsistenciesCallout';
+import { PromoteInconsistency } from '../../../hooks/usePromoteInconsistencies';
 
 export interface PromoteBySpaceModalProps {
   promote: GetPromoteBySpaceResponse['response'];
   closeModal: () => void;
   onConfirm: () => boolean;
   space: PromoteSpaces;
+  inconsistencies?: PromoteInconsistency[];
 }
 
 const PromoteEntity: React.FC<{
@@ -60,11 +63,11 @@ export const PromoteBySpaceModal: React.FC<PromoteBySpaceModalProps> = ({
   onConfirm,
   promote,
   space,
+  inconsistencies,
 }) => {
   const [confirmActionText, setconfirmActionText] = useState('');
 
   const onConfirmClick = async () => {
-    // Generate promote payload
     (await onConfirm()) && closeModal();
   };
 
@@ -96,6 +99,8 @@ export const PromoteBySpaceModal: React.FC<PromoteBySpaceModalProps> = ({
               The entities will be promoted to <b>{nextSpace}</b>. This action is irreversible.
             </EuiText>
           </p>
+
+          <InconsistenciesCallout inconsistencies={inconsistencies ?? []} />
 
           {PROMOTE_ENTITIES_ORDER.map((entity) => {
             const label = PROMOTE_ENTITIES_LABELS[entity];

--- a/public/pages/Integrations/containers/PromoteIntegration.tsx
+++ b/public/pages/Integrations/containers/PromoteIntegration.tsx
@@ -12,10 +12,11 @@ import {
   ROUTES,
 } from '../../../utils/constants';
 import { DataStore } from '../../../store/DataStore';
-import { setBreadcrumbs, successNotificationToast } from '../../../utils/helpers';
+import { setBreadcrumbs } from '../../../utils/helpers';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import {
   EuiButton,
+  EuiCheckbox,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
@@ -26,6 +27,7 @@ import {
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
 import { withGuardAsync } from '../utils/helpers';
 import { PromoteBySpaceModal } from '../components/PromoteModal';
+import { InconsistenciesCallout } from '../components/InconsistenciesCallout';
 import { GetPromoteBySpaceResponse, PromoteChangeGroup, PromoteSpaces } from '../../../../types';
 import { SPACE_ACTIONS } from '../../../../common/constants';
 import { compose } from 'redux';
@@ -35,6 +37,15 @@ import {
 } from '../components/RootDecoderRequirement';
 import { actionIsAllowedOnSpace, getNextSpace } from '../../../../common/helpers';
 import { PromoteChangeDiff } from '../components/PromoteChangeDiff';
+import {
+  MANDATORY_PROMOTE_ENTITIES,
+  usePromoteSelection,
+} from '../../../hooks/usePromoteSelection';
+import {
+  IntegrationChildrenMap,
+  usePromoteInconsistencies,
+} from '../../../hooks/usePromoteInconsistencies';
+import { usePromoteSubmit } from '../../../hooks/usePromoteSubmit';
 
 export interface PromoteIntegrationProps extends RouteComponentProps {
   notifications: NotificationsStart;
@@ -44,26 +55,65 @@ const PromoteEntity: React.FC<{
   label: string;
   entity: PromoteChangeGroup;
   data: GetPromoteBySpaceResponse['response'];
-}> = ({ label, entity, data }) => {
+  selectedIds: Set<string>;
+  onToggleItem: (entity: PromoteChangeGroup, id: string) => void;
+  onToggleAll: (entity: PromoteChangeGroup) => void;
+  mandatory?: boolean;
+}> = ({ label, entity, data, selectedIds, onToggleItem, onToggleAll, mandatory }) => {
   const memoizedData = useMemo(
     () =>
       (data.promote?.changes?.[entity] ?? []).map(({ id, ...rest }) => {
         const strippedId = id.replace(/^\w_/, '');
         const available = data.available_promotions?.[entity];
-        const name = available?.[id] ?? available?.[strippedId] ?? id; // Prefer metadata.title from available_promotions; fallback to id
+        const name = available?.[id] ?? available?.[strippedId] ?? id;
         return { ...rest, id, name };
       }),
     [data.promote?.changes?.[entity], entity, data.available_promotions]
   );
+
+  if (mandatory) {
+    return (
+      <div>
+        <EuiText size="s">
+          <h3>{label}</h3>
+        </EuiText>
+        <EuiSpacer size="s" />
+        <div>
+          {memoizedData.map(({ id, name, operation }, i) => (
+            <PromoteChangeDiff key={`${id}-${i}`} name={name || id} operation={operation} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const allSelected =
+    memoizedData.length > 0 && memoizedData.every(({ id }) => selectedIds.has(id));
+  const someSelected = memoizedData.some(({ id }) => selectedIds.has(id));
+
   return (
     <div>
-      <EuiText size="s">
-        <h3>{label}</h3>
-      </EuiText>
-      <EuiSpacer size="s"></EuiSpacer>
-      <div>
+      <EuiCheckbox
+        id={`promote-toggle-all-${entity}`}
+        checked={allSelected}
+        indeterminate={!allSelected && someSelected}
+        onChange={() => onToggleAll(entity)}
+        label={
+          <EuiText size="s">
+            <h3>{label}</h3>
+          </EuiText>
+        }
+      />
+      <EuiSpacer size="s" />
+      <div style={{ marginLeft: '1.5rem' }}>
         {memoizedData.map(({ id, name, operation }, i) => (
-          <PromoteChangeDiff key={`${id}-${i}`} name={name || id} operation={operation} />
+          <EuiCheckbox
+            key={`${entity}-${id}-${i}`}
+            id={`promote-item-${entity}-${id}-${i}`}
+            checked={selectedIds.has(id)}
+            onChange={() => onToggleItem(entity, id)}
+            label={<PromoteChangeDiff name={name || id} operation={operation} />}
+          />
         ))}
       </div>
     </div>
@@ -73,11 +123,10 @@ const PromoteEntity: React.FC<{
 const PromoteBySpace: React.FC<{ space: PromoteSpaces }> = compose(
   withConditionalHOC((props) => {
     return actionIsAllowedOnSpace(props.space, SPACE_ACTIONS.DEFINE_ROOT_DECODER);
-  }, withRootDecoderRequirementGuard), // This guard is added to make sure that the user has a root decoder defined before promoting, as it is a requirement for the promotion. If the user doesn't have a root decoder defined, it will show a message to the user to define a root decoder before promoting.
+  }, withRootDecoderRequirementGuard),
   withGuardAsync(
     async ({ space }) => {
       try {
-        // Get promotions by space
         const [ok, data] = await DataStore.integrations.getPromote({ space });
 
         if (!ok) {
@@ -87,9 +136,15 @@ const PromoteBySpace: React.FC<{ space: PromoteSpaces }> = compose(
           };
         }
 
+        const integrationIds = (data.promote?.changes?.integrations ?? []).map((item) => item.id);
+        const integrationChildren = await DataStore.integrations.getIntegrationChildrenMap(
+          space,
+          integrationIds
+        );
+
         return {
           ok: true,
-          data: { promoteData: data },
+          data: { promoteData: data, integrationChildren },
         };
       } catch (error) {
         return {
@@ -102,33 +157,37 @@ const PromoteBySpace: React.FC<{ space: PromoteSpaces }> = compose(
     },
     ({
       promoteData,
+      integrationChildren,
       space,
       notifications,
       history,
     }: {
       promoteData: GetPromoteBySpaceResponse['response'];
+      integrationChildren: IntegrationChildrenMap;
       space: PromoteSpaces;
       notifications: PromoteIntegrationProps['notifications'];
     }) => {
       const [modalIsOpen, setModalIsOpen] = useState(false);
 
-      // TODO: add ability to select which entities to promote
-      const hasPromotions = Object.values(promoteData.promote.changes).some(
-        (items) => items.length > 0
-      );
+      const {
+        selected,
+        toggleItem,
+        toggleAll,
+        selectAllGlobal,
+        deselectAllGlobal,
+        selectedChanges,
+        selectedPromoteData,
+        hasPromotions,
+        hasSelected,
+      } = usePromoteSelection(promoteData);
 
-      const onConfirmPromote = async () => {
-        // TODO: generate promote payload based on the selected entities to promote. For now, we are promoting all the entities.
-        const success = await DataStore.integrations.promoteIntegration({
-          space,
-          changes: promoteData.promote.changes,
-        });
-        if (success) {
-          successNotificationToast(notifications, 'promoted', `[${space}] space`);
-          history.push(ROUTES.INTEGRATIONS);
-        }
-        return success;
-      };
+      const inconsistencies = usePromoteInconsistencies(promoteData, selected, integrationChildren);
+
+      const submitPromote = usePromoteSubmit({
+        space,
+        notifications,
+        onSuccess: () => history.push(ROUTES.INTEGRATIONS),
+      });
 
       if (!hasPromotions) {
         return <EuiText>There is nothing to promote.</EuiText>;
@@ -139,18 +198,42 @@ const PromoteBySpace: React.FC<{ space: PromoteSpaces }> = compose(
           {modalIsOpen && (
             <PromoteBySpaceModal
               closeModal={() => setModalIsOpen(false)}
-              promote={promoteData}
-              onConfirm={onConfirmPromote}
+              promote={selectedPromoteData}
+              onConfirm={() => submitPromote(selectedChanges)}
               space={space}
-            ></PromoteBySpaceModal>
+              inconsistencies={inconsistencies}
+            />
           )}
+          <InconsistenciesCallout inconsistencies={inconsistencies} />
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiButton size="s" onClick={selectAllGlobal}>
+                Select all
+              </EuiButton>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton size="s" onClick={deselectAllGlobal}>
+                Deselect all
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="m" />
           <div>
-            {PROMOTE_ENTITIES_ORDER.map((entity) => {
+            {PROMOTE_ENTITIES_ORDER.map((entityKey) => {
+              const entity = entityKey as PromoteChangeGroup;
               if ((promoteData?.promote?.changes?.[entity]?.length ?? 0) > 0) {
                 const label = PROMOTE_ENTITIES_LABELS[entity];
                 return (
                   <React.Fragment key={entity}>
-                    <PromoteEntity label={label} entity={entity} data={promoteData} />
+                    <PromoteEntity
+                      label={label}
+                      entity={entity}
+                      data={promoteData}
+                      selectedIds={selected[entity] ?? new Set<string>()}
+                      onToggleItem={toggleItem}
+                      onToggleAll={toggleAll}
+                      mandatory={MANDATORY_PROMOTE_ENTITIES.has(entity)}
+                    />
                     <EuiSpacer size="m" />
                   </React.Fragment>
                 );
@@ -161,7 +244,7 @@ const PromoteBySpace: React.FC<{ space: PromoteSpaces }> = compose(
           <EuiSpacer size="m" />
           <EuiFlexGroup justifyContent="flexEnd">
             <EuiFlexItem grow={false}>
-              <EuiButton disabled={!hasPromotions} onClick={() => setModalIsOpen(true)} fill={true}>
+              <EuiButton disabled={!hasSelected} onClick={() => setModalIsOpen(true)} fill={true}>
                 Promote
               </EuiButton>
             </EuiFlexItem>
@@ -169,7 +252,8 @@ const PromoteBySpace: React.FC<{ space: PromoteSpaces }> = compose(
         </>
       );
     },
-    EuiLoadingSpinner
+    EuiLoadingSpinner,
+    {}
   )
 )(({ errorPromote }) => {
   return <EuiText color="danger">{errorPromote}</EuiText>;
@@ -191,7 +275,6 @@ export const PromoteIntegration: React.FC<PromoteIntegrationProps> = ({
     <EuiPanel>
       <PageHeader appDescriptionControls={[{ description }]}>
         <EuiText size="s">
-          {/* Log Type is replaced with Integration by Wazuh */}
           <h1>Promote</h1>
         </EuiText>
         <EuiText size="s" color="subdued">

--- a/public/store/IntegrationStore.ts
+++ b/public/store/IntegrationStore.ts
@@ -260,13 +260,68 @@ export class IntegrationStore {
     return [promoteRes.ok, promoteRes.response];
   }
 
-  public async promoteIntegration(data: PromoteIntegrationRequestBody) {
+  public async promoteIntegration(
+    data: PromoteIntegrationRequestBody
+  ): Promise<{ ok: boolean; error?: string }> {
     const promoteRes = await this.service.promoteIntegration(data);
+
     if (!promoteRes.ok) {
-      errorNotificationToast(this.notifications, 'promote', 'integration', promoteRes.error);
+      const errorMessage = this.getErrorMessage(promoteRes.error, 'Failed to promote integration');
+      errorNotificationToast(this.notifications, 'promote', 'integration', errorMessage);
+      return { ok: false, error: errorMessage };
     }
 
-    return promoteRes.ok;
+    const inner: any = (promoteRes as any).response;
+    if (inner && inner.ok === false) {
+      const errorMessage = this.getErrorMessage(
+        inner.error ?? inner.message,
+        'Failed to promote integration'
+      );
+      errorNotificationToast(this.notifications, 'promote', 'integration', errorMessage);
+      return { ok: false, error: errorMessage };
+    }
+
+    return { ok: true };
+  }
+
+  /**
+   * Fetches the bundled children (decoders, rules, kvdbs) of a given set of
+   * integrations in a source space. Used to produce precise dependency
+   * warnings in the promote preview.
+   */
+  public async getIntegrationChildrenMap(
+    space: string,
+    integrationIds: string[]
+  ): Promise<
+    Record<string, { title: string; decoders: string[]; rules: string[]; kvdbs: string[] }>
+  > {
+    if (integrationIds.length === 0) {
+      return {};
+    }
+    try {
+      const searchRes = await this.service.searchIntegrations({ spaceFilter: space });
+      if (!searchRes.ok) {
+        return {};
+      }
+      const wanted = new Set(integrationIds);
+      const result: Record<
+        string,
+        { title: string; decoders: string[]; rules: string[]; kvdbs: string[] }
+      > = {};
+      for (const hit of searchRes.response.hits.hits) {
+        const doc = hit._source.document;
+        if (!wanted.has(doc.id)) continue;
+        result[doc.id] = {
+          title: doc.metadata?.title ?? doc.id,
+          decoders: doc.decoders ?? [],
+          rules: doc.rules ?? [],
+          kvdbs: doc.kvdbs ?? [],
+        };
+      }
+      return result;
+    } catch {
+      return {};
+    }
   }
 
   /**

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -265,10 +265,10 @@ export const errorNotificationToast = (
     return;
   }
   const message = `Failed to ${actionName} ${objectName}:`;
-  console.error(message, msg);
+  console.error(message, errorMessage);
   notifications?.toasts.addDanger({
     title: message,
-    text: msg,
+    text: errorMessage,
     toastLifeTimeMs: displayTime,
   });
 };


### PR DESCRIPTION
### Description

- Refactors the Integrations **Promote** page so users can pick exactly which items to promote between space (integrations,decoders, KVDBs, rules) instead of a coarse all-or-nothing submit. Policy continues to travel with  every promotion but is rendered as read-only info.

- Adds dependency-aware inconsistency detection that warns the user , both in-page and inside the confirm modal  when the selection would leave the target space with orphan or broken references (e.g. rules selected but their parent integration is not). Uses the integration document's bundled `decoders` / `rules` / `kvdbs` lists for precise per-integration warnings.


### Issues Resolved
Closes #228  
https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/228


### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).