### PR TITLE
Fixes variable name consistency in error notification

### DIFF
--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -265,10 +265,10 @@ export const errorNotificationToast = (
     return;
   }
   const message = `Failed to ${actionName} ${objectName}:`;
-  console.error(message, msg);
+  console.error(message, errorMessage);
   notifications?.toasts.addDanger({
     title: message,
-    text: msg,
+    text: errorMessage,
     toastLifeTimeMs: displayTime,
   });
 };


### PR DESCRIPTION
### Description

Replace the “msg” property with “errorMessage,” since “msg” was removed after the update to make it compatible with version 3.6.0

### Issues Resolved

- #179 

### Screenshot

<img width="2234" height="1368" alt="image" src="https://github.com/user-attachments/assets/bf80f64f-5303-4c8e-aa85-ceb34837b3be" />

