### PR TITLE
 Fix detector details race after creation and use GET-by-id for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@ All notable changes to the Wazuh ML Commons project will be documented in this f
 - Fixed data source didn't include data stream aliases for detector creation [#116](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/116)
 - Fixed decoders form not handling request errors properly [#194](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/194)
 - Fixed float numbers ending in .0 in the Decoders yaml editor being transformed into integers [#200](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/200)
+- Fixed detector details failing to load right after detector creation [#249](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/249)

--- a/public/pages/CreateDetector/containers/CreateDetector.tsx
+++ b/public/pages/CreateDetector/containers/CreateDetector.tsx
@@ -185,16 +185,16 @@ export default class CreateDetector extends Component<
     const createDetectorPromise =
       this.props.services.detectorsService.createDetector(detector);
 
-    this.setState({ creatingDetector: false }, () => {
-      // set detector pending state, this will be used in detector details page
-      DataStore.detectors.setState(
-        {
-          pendingRequests: [fieldsMappingPromise, createDetectorPromise],
-          detectorInput: { ...this.state },
-        },
-        this.props.history,
-      );
-    });
+    // set detector pending state, this will be used in detector details page
+    DataStore.detectors.setState(
+      {
+        pendingRequests: [fieldsMappingPromise, createDetectorPromise],
+        detectorInput: { ...this.state },
+      },
+      this.props.history,
+    );
+
+    this.setState({ creatingDetector: false });
 
     this.props.metrics.detectorMetricsManager.sendMetrics(
       CreateDetectorSteps.createClicked,

--- a/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
+++ b/public/pages/Detectors/containers/Detector/DetectorDetails.tsx
@@ -238,6 +238,10 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
 
   async componentDidMount() {
     const state = DataStore.detectors.getState();
+    if (!state && this.state.detectorId === PENDING_DETECTOR_ID) {
+      this.props.history.push(ROUTES.DETECTORS);
+      return;
+    }
     state ? this.getPendingDetector() : this.getDetector();
   }
 
@@ -245,7 +249,12 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
   async getDetectorSpace(detector: DetectorHit) {
     try {
       // Wazuh: get the integration "space" to assign the detector
-      const { custom_rules, pre_packaged_rules } = detector._source.inputs[0].detector_input;
+      const detectorInputContainer: any = detector?._source ?? detector;
+      const detectorInput = detectorInputContainer?.inputs?.[0]?.detector_input;
+      if (!detectorInput) {
+        return;
+      }
+      const { custom_rules, pre_packaged_rules } = detectorInput;
       // Take the first one rule to extrapolate the space
       const ruleForMapping = [...custom_rules, ...pre_packaged_rules].find(
         ({ id }) => typeof id !== 'undefined'
@@ -273,11 +282,15 @@ export class DetectorDetails extends React.Component<DetectorDetailsProps, Detec
     const { detectorService, notifications } = this.props;
     try {
       const { detectorId } = this.state;
-      const response = await detectorService.getDetectors();
+      // GET by id (read-your-own-writes consistent), avoids eventual-consistency
+      // miss right after creation that occurs with search.
+      const response = await detectorService.getDetectorWithId(detectorId);
       if (response.ok) {
-        const detector = response.response.hits.hits.find(
-          (detectorHit) => detectorHit._id === detectorId
-        ) as DetectorHit;
+        const detector = {
+          _id: response.response._id,
+          _index: '',
+          _source: response.response.detector,
+        } as DetectorHit;
 
         const space = await this.getDetectorSpace(detector);
 


### PR DESCRIPTION

### Description
  - Order `DataStore.detectors.setState` before `setState({ creatingDetector: false })` in `CreateDetector` so the pending state is in place before navigation to the details page (fixes a race that left the details page without context).                                                                             
  - In `DetectorDetails.componentDidMount`, redirect to the detectors list when the route is the pending detector but no DataStore state exists (e.g. direct navigation / refresh).                                                                                                                                      
  - Replace `detectorService.getDetectors()` (search-backed, eventually consistent) with `detectorService.getDetectorWithId(detectorId)`  (read-your-own-writes) to avoid the just-created detector not appearing in search results.                                                                  
  - Make `getDetectorSpace` defensive against missing `_source.inputs[0].detector_input`.

### Issues Resolved
 closes #246 

### Evidence

https://github.com/user-attachments/assets/d582371b-033a-4206-83c0-b42b028a50ea

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).