### PR TITLE
Fix tag references on bump when --tag is provided

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -465,7 +465,7 @@ update_branch_reference_defaults() {
     return 0
   fi
 
-  local bump_string="$VERSION"
+  local bump_string="$GIT_REF_REPLACEMENT"
   local files=(
     "${REPO_PATH}/.github/workflows/5_builderpackage_security_analytics_plugin.yml"
     "${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
@@ -533,6 +533,20 @@ update_imposter_config() {
   }
 }
 
+get_git_ref_replacement(){
+  local replacement
+  if [ "$TAG" = true ]; then
+    replacement="v${VERSION}"
+    if [ -n "$STAGE" ]; then
+      replacement+="-${STAGE}"
+    fi
+  else
+    replacement="${VERSION}"
+  fi
+
+  GIT_REF_REPLACEMENT="$replacement"
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -561,6 +575,8 @@ main() {
 
   # Compare versions and determine revision
   compare_versions_and_set_revision
+
+  get_git_ref_replacement
 
   # Start file modifications
   log "Starting file modifications..."


### PR DESCRIPTION
### Description

This pull request fixes the git references in some files on bump when --tag is provided.

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard/issues/1295

### Evidences

```diff
diff --git a/.github/workflows/5_builderpackage_security_analytics_plugin.yml b/.github/workflows/5_builderpackage_security_analytics_plugin.yml
index bbe5b5a7..a8e113b9 100644
--- a/.github/workflows/5_builderpackage_security_analytics_plugin.yml
+++ b/.github/workflows/5_builderpackage_security_analytics_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: v5.0.0-beta3
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index ce93fcc1..d8841c31 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -20,7 +20,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 5fae2839..9ecf80ce 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh ML Commons project will be documented in this file.
 
-## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 02
+## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 03
 
 ### Added
 
diff --git a/VERSION.json b/VERSION.json
index 0533024c..a57868ae 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "5.0.0",
-  "stage": "beta2"
+  "stage": "beta3"
 }
diff --git a/package.json b/package.json
index 9892c79b..c79964a1 100644
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "wazuh": {
     "version": "5.0.0",
-    "revision": "02"
+    "revision": "03"
   },
   "config": {
     "id": "securityAnalyticsDashboards",
```

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## Other

| Test | Result |
| --- |  --- |
| Run `./repository_bumper.sh --tag --stage beta3`, then check the references to `main` were changed to the tag `git --no-pager diff` | :black_circle: |

**Details**
<details>
<summary>:black_circle: Run `./repository_bumper.sh --tag --stage beta3`, then check the references to `main` were changed to the tag `git --no-pager diff`</summary>

</details>

### Check List
- [x] Commits are signed per the DCO using --signoff
