### PR TITLE
Enhance RuleContentViewer to safely load YAML for detection data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to the Wazuh ML Commons project will be documented in this f
 
 - Fixed YAML Editor when creating or editing detection rules [#9](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/9)
 - Fixed detection rule editor causing blank screen [#44](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/44)
+- Fixed rule JSON viewer showing the detection field as a YAML string instead of a structured object [#315](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/315)
 - Fixed data source didn't include data stream aliases for detector creation [#116](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/116)
 - Fixed decoders form not handling request errors properly [#194](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/194)
 - Fixed float numbers ending in .0 in the Decoders yaml editor being transformed into integers [#200](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/200)

--- a/public/pages/WazuhRules/components/RuleContentViewer/RuleContentViewer.tsx
+++ b/public/pages/WazuhRules/components/RuleContentViewer/RuleContentViewer.tsx
@@ -214,6 +214,7 @@ export const RuleContentViewer: React.FC<RuleContentViewerProps> = ({
           {JSON.stringify(
             {
               ...ruleData,
+              detection: ruleData.detection ? safeLoadYaml(ruleData.detection) : undefined,
               mitre: ruleData.mitre ? safeLoadYaml(ruleData.mitre) : undefined,
               compliance: ruleData.compliance ? safeLoadYaml(ruleData.compliance) : undefined,
             },


### PR DESCRIPTION
### Description

Fixes the rule JSON viewer so the `detection` field is rendered as a structured object instead of a raw YAML string.

In the Wazuh Rules flyout, `detection` is stored internally as a YAML string (converted from the indexed object in `WazuhRulesStore`). The JSON tab already parsed `mitre` and `compliance` with `safeLoadYaml` before serialization, but `detection` was left as a string via the spread of `ruleData`. This change applies the same parsing to `detection`, so the JSON view shows a proper nested object (e.g. `condition`, `selection`, field modifiers) instead of escaped YAML text.

### Issues Resolved

- Fixes https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/314

### Evidence 
<img width="1919" height="940" alt="image" src="https://github.com/user-attachments/assets/85e28937-5f4c-4cd0-be60-1d7ea18de986" />


### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).