### PR TITLE
fix: show full documentation text in integration view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,4 @@ All notable changes to the Wazuh ML Commons project will be documented in this f
 - Fixed decoders form not handling request errors properly [#194](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/194)
 - Fixed float numbers ending in .0 in the Decoders yaml editor being transformed into integers [#200](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/200)
 - Fixed detector details failing to load right after detector creation [#249](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/249)
+- Fixed integration documentation field being truncated in the details view [#322](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/322)

--- a/public/pages/Integrations/components/EditPolicy.tsx
+++ b/public/pages/Integrations/components/EditPolicy.tsx
@@ -311,7 +311,7 @@ const EditForm: React.FC<{}> = withPolicyGuard({
           }
         >
           {canEditPolicy ? (
-            <EuiCompressedFieldText
+            <EuiCompressedTextArea
               value={policyDetails.metadata?.documentation || ''}
               onChange={(e) => {
                 const newPolicy = {

--- a/public/pages/Integrations/components/IntegrationForm.tsx
+++ b/public/pages/Integrations/components/IntegrationForm.tsx
@@ -42,21 +42,24 @@ interface ReadOnlyFieldProps {
   value: string | undefined;
   placeholder?: string;
   isTextArea?: boolean;
+  noTruncate?: boolean;
 }
 
 const ReadOnlyField: React.FC<ReadOnlyFieldProps> = ({
   value,
   placeholder = '-',
   isTextArea = false,
+  noTruncate = false,
 }) => (
   <EuiText
     size="s"
     style={{
       padding: '6px 0',
-      lineHeight: isTextArea ? '1.5' : '20px',
-      whiteSpace: isTextArea ? 'pre-wrap' : 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
+      lineHeight: isTextArea || noTruncate ? '1.5' : '20px',
+      whiteSpace: isTextArea || noTruncate ? 'pre-wrap' : 'nowrap',
+      overflow: noTruncate ? 'visible' : 'hidden',
+      textOverflow: noTruncate ? 'clip' : 'ellipsis',
+      wordBreak: noTruncate ? 'break-word' : undefined,
     }}
   >
     {value || placeholder}
@@ -331,6 +334,7 @@ export const IntegrationForm = forwardRef<IntegrationFormHandle, IntegrationForm
             )
           }
           helpText={isEditMode && 'Must contain 2-100 characters.'}
+          fullWidth={!isEditMode}
         >
           {isEditMode ? (
             <EuiCompressedFieldText
@@ -352,7 +356,7 @@ export const IntegrationForm = forwardRef<IntegrationFormHandle, IntegrationForm
               disabled={!!integrationDetails.detectionRulesCount}
             />
           ) : (
-            <ReadOnlyField value={integrationDetails?.document.metadata?.documentation} />
+            <ReadOnlyField value={integrationDetails?.document.metadata?.documentation} noTruncate />
           )}
         </EuiCompressedFormRow>
         <EuiSpacer />

--- a/public/pages/Integrations/components/IntegrationForm.tsx
+++ b/public/pages/Integrations/components/IntegrationForm.tsx
@@ -57,9 +57,9 @@ const ReadOnlyField: React.FC<ReadOnlyFieldProps> = ({
       padding: '6px 0',
       lineHeight: isTextArea || noTruncate ? '1.5' : '20px',
       whiteSpace: isTextArea || noTruncate ? 'pre-wrap' : 'nowrap',
-      overflow: noTruncate ? 'visible' : 'hidden',
-      textOverflow: noTruncate ? 'clip' : 'ellipsis',
-      wordBreak: noTruncate ? 'break-word' : undefined,
+      overflow: isTextArea || noTruncate ? 'visible' : 'hidden',
+      textOverflow: isTextArea || noTruncate ? undefined : 'ellipsis',
+      textAlign: isTextArea || noTruncate ? 'justify' : undefined,
     }}
   >
     {value || placeholder}
@@ -297,6 +297,7 @@ export const IntegrationForm = forwardRef<IntegrationFormHandle, IntegrationForm
               'Description'
             )
           }
+          fullWidth={!isEditMode}
         >
           {isEditMode ? (
             <EuiCompressedTextArea
@@ -337,7 +338,7 @@ export const IntegrationForm = forwardRef<IntegrationFormHandle, IntegrationForm
           fullWidth={!isEditMode}
         >
           {isEditMode ? (
-            <EuiCompressedFieldText
+            <EuiCompressedTextArea
               value={editingIntegration?.document.metadata?.documentation}
               onChange={(e) => {
                 const newIntegration = {
@@ -354,6 +355,7 @@ export const IntegrationForm = forwardRef<IntegrationFormHandle, IntegrationForm
                 updateErrors(newIntegration);
               }}
               disabled={!!integrationDetails.detectionRulesCount}
+              placeholder="Documentation of the integration"
             />
           ) : (
             <ReadOnlyField value={integrationDetails?.document.metadata?.documentation} noTruncate />

--- a/public/pages/Integrations/components/PolicyInfoCard.tsx
+++ b/public/pages/Integrations/components/PolicyInfoCard.tsx
@@ -32,11 +32,23 @@ const truncateStyle: React.CSSProperties = {
   wordBreak: 'break-all',
 };
 
-const renderValue = (value: string | undefined | null): React.ReactNode => {
+const fullValueStyle: React.CSSProperties = {
+  display: '-webkit-box',
+  WebkitLineClamp: 'unset',
+  WebkitBoxOrient: 'vertical',
+  overflow: 'visible',
+  textOverflow: 'ellipsis',
+  wordBreak: 'break-all',
+};
+
+const renderValue = (
+  value: string | undefined | null,
+  noTruncate: boolean = false
+): React.ReactNode => {
   if (!value) return '-';
 
   return (
-    <span title={value} style={truncateStyle}>
+    <span title={value} style={noTruncate ? fullValueStyle : truncateStyle}>
       {value}
     </span>
   );
@@ -367,7 +379,7 @@ const renderDetailsPanel = (
         <EuiDescriptionList>
           <EuiDescriptionListTitle>Documentation</EuiDescriptionListTitle>
           <EuiDescriptionListDescription>
-            {renderValue(typeof documentation === 'string' ? documentation : undefined)}
+            {renderValue(typeof documentation === 'string' ? documentation : undefined, true)}
           </EuiDescriptionListDescription>
         </EuiDescriptionList>
       </EuiFlexItem>

--- a/public/pages/Integrations/components/PolicyInfoCard.tsx
+++ b/public/pages/Integrations/components/PolicyInfoCard.tsx
@@ -37,8 +37,7 @@ const fullValueStyle: React.CSSProperties = {
   WebkitLineClamp: 'unset',
   WebkitBoxOrient: 'vertical',
   overflow: 'visible',
-  textOverflow: 'ellipsis',
-  wordBreak: 'break-all',
+  textAlign: 'justify',
 };
 
 const renderValue = (
@@ -387,7 +386,7 @@ const renderDetailsPanel = (
         <EuiDescriptionList>
           <EuiDescriptionListTitle>Description</EuiDescriptionListTitle>
           <EuiDescriptionListDescription>
-            {renderValue(typeof description === 'string' ? description : undefined)}
+            {renderValue(typeof description === 'string' ? description : undefined, true)}
           </EuiDescriptionListDescription>
         </EuiDescriptionList>
       </EuiFlexItem>


### PR DESCRIPTION
### Description
 In the integration details view, the **Documentation** field was  rendered with single-line truncation (`nowrap` + `ellipsis`), which hid most of the content when the documentation was long.

### Issues Resolved
Closes #321 

### Evidence 
<img width="1496" height="787" alt="image" src="https://github.com/user-attachments/assets/4ee44a6e-7c3e-4a2c-9dff-211a2ab950ad" />

### Test 
  1. Go to Security Analytics → Integrations (Standard).
  2. Open an integration with long documentation text.
  3. Confirm the Documentation field shows the full text wrapped, not truncated with "…".
  4. 
### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).