### PR TITLE
Add --tag parameter to bumper repository workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -14,6 +14,16 @@ on:
         default: ""
         required: false
         type: string
+      tag:
+        description: "Change branches references to tag-like references (e.g. v4.12.0-alpha7)"
+        default: false
+        required: false
+        type: boolean
+      set_as_main:
+        description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
+        required: false
+        type: boolean
+        default: false
       issue-link:
         description: "Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>"
         required: true
@@ -22,11 +32,6 @@ on:
         description: "Optional identifier for the run"
         required: false
         type: string
-      set_as_main:
-        description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
-        required: false
-        type: boolean
-        default: false
       revert:
         description: "Set to true to revert the bump changes applied for this issue"
         default: false
@@ -85,17 +90,22 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
-          set_as_main: ${{ inputs.set_as_main }}
+          TAG: ${{ inputs.tag }}
+          SET_AS_MAIN: ${{ inputs.set_as_main }}
         run: |
           script_params=""
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
+          tag=${{ env.TAG }}
+          set_as_main=${{ env.SET_AS_MAIN }}
 
-          # Both version and stage provided
-          if [[ -n "$version" && -n "$stage" ]]; then
+          # Both version and stage provided (no tag)
+          if [[ -n "$version" && -n "$stage" && "$tag" != "true" ]]; then
             script_params="--version ${version} --stage ${stage}"
-          elif [[ -z "$version" && -n "$stage" ]]; then
-            script_params="--stage ${stage}"
+          elif [[ -z "$version" && -n "$stage" && "$tag" == "true" ]]; then
+            script_params="--stage ${stage} --tag"
+          elif [[ -z "$version" && -z "$stage" && "$tag" == "true" ]]; then
+            script_params="--tag"
           fi
 
           if [[ "$set_as_main" == "true" ]]; then


### PR DESCRIPTION
### Description

Adds the missing `tag` input to the repository bumper workflow (`5_bumper_repository.yml`) and wires it to `tools/repository_bumper.sh --tag`, matching the behavior in `wazuh-dashboard-plugins` and `wazuh-security-dashboards-plugin`.

When `tag=true`, branch references in builder workflows are updated to tag-like values (for example `v5.0.0-beta4`) instead of branch names (for example `5.0.0`).

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/330

### How to test

From the repo root:

```bash
# Normal bump (no tag)
bash tools/repository_bumper.sh --version 5.0.0 --stage beta4
# Expected: default: 5.0.0 in builder workflows

# Tag bump with stage
bash tools/repository_bumper.sh --stage beta4 --tag
# Expected: default: v5.0.0-beta4 in builder workflows

# Tag bump only
bash tools/repository_bumper.sh --tag
# Expected: default: v5.0.0 in builder workflows

```
### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).