### PR TITLE
Fix wrong editions on bumper for tag flag

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -384,9 +384,15 @@ compare_versions_and_set_revision() {
         # Ensure CURRENT_REVISION is treated as a number (remove leading zeros for arithmetic if necessary, handle base 10)
         local current_revision_int=$((10#$current_revision_val))
         local new_revision_int=$((current_revision_int + 1))
-        # Format back to two digits with leading zero
-        REVISION=$(printf "%02d" "$new_revision_int")
-        log "Current revision: $current_revision_val. New revision set to: $REVISION"
+        if [ -n "$STAGE" ] && [ "$STAGE" != "$CURRENT_STAGE" ]; then
+          # Format back to two digits with leading zero
+          log "Incrementing revision."
+          REVISION=$(printf "%02d" "$new_revision_int")
+          log "Current revision: $current_revision_val. New revision set to: $REVISION"
+        else
+          REVISION=$(printf "%02d" "$current_revision_int")
+          log "Current revision: $current_revision_val."
+        fi
       fi
     fi
   fi
@@ -407,7 +413,7 @@ update_root_version_json() {
     fi
 
     # Update stage in VERSION.json
-    if [[ "$CURRENT_STAGE" != "$STAGE" ]]; then
+    if [ -n "$STAGE" ] && [[ "$CURRENT_STAGE" != "$STAGE" ]]; then
       sed_inplace "s/^[[:space:]]*\"stage\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/  \"stage\": \"$STAGE\"/" "$VERSION_FILE"
       modified=true
     fi


### PR DESCRIPTION
### Description
This pull request fixes wrong editions on bumper for --tag flag.

### Issues Resolved
#330

### Evicence

```console
$ bash tools/repository_bumper.sh --tag
[2026-06-10 11:41:16] Starting repository bump process
[2026-06-10 11:41:16] Repository path: /home/toni/wazuh/src/wazuh-dashboard-security-analytics
[2026-06-10 11:41:16] Version: 
[2026-06-10 11:41:16] Stage: 
[2026-06-10 11:41:16] Attempting to extract current version from /home/toni/wazuh/src/wazuh-dashboard-security-analytics/VERSION.json using sed...
[2026-06-10 11:41:16] Successfully extracted version using sed: 5.0.0
[2026-06-10 11:41:16] Current version detected in VERSION.json: 5.0.0
[2026-06-10 11:41:16] Attempting to extract current stage from /home/toni/wazuh/src/wazuh-dashboard-security-analytics/VERSION.json using sed...
[2026-06-10 11:41:16] Successfully extracted stage using sed: beta3
[2026-06-10 11:41:16] Current stage detected in VERSION.json: beta3
[2026-06-10 11:41:16] Attempting to extract current revision from /home/toni/wazuh/src/wazuh-dashboard-security-analytics/package.json using sed...
[2026-06-10 11:41:16] Successfully extracted revision using sed: 03
[2026-06-10 11:41:16] Current revision detected in package.json: 03
[2026-06-10 11:41:16] Default revision set to: 00
[2026-06-10 11:41:16] Comparing new version (5.0.0) with current version (5.0.0)...
[2026-06-10 11:41:16] New version (5.0.0) is identical to current version (5.0.0). Incrementing revision.
[2026-06-10 11:41:16] Attempting to extract current revision from /home/toni/wazuh/src/wazuh-dashboard-security-analytics/package.json using sed (Note: This is fragile)
[2026-06-10 11:41:16] Successfully extracted revision using sed: 03
[2026-06-10 11:41:16] Current revision: 03.
[2026-06-10 11:41:16] Final revision determined: 03
[2026-06-10 11:41:16] Starting file modifications...
[2026-06-10 11:41:16] Processing /home/toni/wazuh/src/wazuh-dashboard-security-analytics/VERSION.json
[2026-06-10 11:41:16] Processing /home/toni/wazuh/src/wazuh-dashboard-security-analytics/package.json
[2026-06-10 11:41:16] Updating CHANGELOG.md...
[2026-06-10 11:41:16] Attempting to extract .version from /home/toni/wazuh/src/wazuh-dashboard-security-analytics/package.json using sed (Note: This is fragile)
[2026-06-10 11:41:16] Detected OpenSearch Dashboards version for changelog: 3.6.0
[2026-06-10 11:41:16] Replacing default: main with default: v5.0.0 in /home/toni/wazuh/src/wazuh-dashboard-security-analytics/.github/workflows/5_builderpackage_security_analytics_plugin.yml (where applicable)
[2026-06-10 11:41:16] Replacing default: main with default: v5.0.0 in /home/toni/wazuh/src/wazuh-dashboard-security-analytics/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-06-10 11:41:16] File modifications completed.
[2026-06-10 11:41:16] Repository bump completed successfully. Log file: /home/toni/wazuh/src/wazuh-dashboard-security-analytics/tools/repository_bumper_2026-06-10_11-41-16-448.log
```

```diff
$ git diff
diff --git a/.github/workflows/5_builderpackage_security_analytics_plugin.yml b/.github/workflows/5_builderpackage_security_analytics_plugin.yml
index bbe5b5a7..fc334d2d 100644
--- a/.github/workflows/5_builderpackage_security_analytics_plugin.yml
+++ b/.github/workflows/5_builderpackage_security_analytics_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: v5.0.0
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index ce93fcc1..94bb9a5c 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -20,7 +20,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true
```

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## Other

| Test | Result |
| --- |  --- |
| With clean repo, run bash tools/repository_bumper.sh --tag, this should not change the stage in VERSION.JSON and revision in package.json. Use git diff to check it. | :black_circle: |

**Details**
<details>
<summary>:black_circle: With clean repo, run bash tools/repository_bumper.sh --tag, this should not change the stage in VERSION.JSON and revision in package.json. Use git diff to check it.</summary>

</details>

### Check List
- [x] Commits are signed per the DCO using --signoff
