### PR TITLE
Remove integration label formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the Wazuh ML Commons project will be documented in this f
 - Rules table and details now display the real integration title. [#164](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/164)
 - Updated nav menu group label to "Security analytics" to match Wazuh Dashboard capitalization style. [#178](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/178)
 - Made Sigma detectors read-only in the UI and centralized the detector source vocabulary [#243](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/243)
+- Removed getLogTypeLabel usage across Security analytics [#353](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/353)
 
 ### Removed
 

--- a/public/components/IntegrationComboBox/IntegrationComboBox.tsx
+++ b/public/components/IntegrationComboBox/IntegrationComboBox.tsx
@@ -138,7 +138,7 @@ export const IntegrationComboBox: React.FC<IntegrationComboBoxProps> = ({
           <EuiSpacer size="m" />
           <EuiCallOut title="No integrations available" color="warning" iconType="alert">
             <p>
-              There are no integrations in {space} status available to add {resourceName}. Please
+              There are no integrations in {space} space available to add {resourceName}. Please
               create an integration first before adding {resourceName}.
             </p>
           </EuiCallOut>

--- a/public/components/IntegrationComboBox/IntegrationComboBox.tsx
+++ b/public/components/IntegrationComboBox/IntegrationComboBox.tsx
@@ -15,7 +15,6 @@ import {
 import React, { useState } from 'react';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import FormFieldHeader from '../FormFieldHeader';
-import { getLogTypeLabel } from '../../pages/LogTypes/utils/helpers';
 import { IntegrationOption } from './useIntegrationSelector';
 import { CreateIntegrationFlyout } from '../../pages/Integrations/components/CreateIntegrationFlyout';
 
@@ -90,7 +89,7 @@ export const IntegrationComboBox: React.FC<IntegrationComboBoxProps> = ({
                     ? [
                         {
                           value: selectedOption.value,
-                          label: getLogTypeLabel(selectedOption.value),
+                          label: selectedOption.value,
                         },
                       ]
                     : []
@@ -123,7 +122,7 @@ export const IntegrationComboBox: React.FC<IntegrationComboBoxProps> = ({
                 ? [
                     {
                       value: selectedOption.value,
-                      label: getLogTypeLabel(selectedOption.value),
+                      label: selectedOption.value,
                     },
                   ]
                 : []

--- a/public/components/IntegrationComboBox/IntegrationComboBox.tsx
+++ b/public/components/IntegrationComboBox/IntegrationComboBox.tsx
@@ -31,6 +31,7 @@ interface IntegrationComboBoxProps {
   'data-test-subj'?: string;
   isInvalid?: boolean;
   error?: string;
+  space?: string;
 }
 
 export const IntegrationComboBox: React.FC<IntegrationComboBoxProps> = ({
@@ -44,6 +45,7 @@ export const IntegrationComboBox: React.FC<IntegrationComboBoxProps> = ({
   'data-test-subj': dataTestSubj,
   isInvalid,
   error,
+  space = 'draft',
 }) => {
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
   const selectedOption = options.find((o) => o.id === selectedId);
@@ -136,8 +138,8 @@ export const IntegrationComboBox: React.FC<IntegrationComboBoxProps> = ({
           <EuiSpacer size="m" />
           <EuiCallOut title="No integrations available" color="warning" iconType="alert">
             <p>
-              There are no integrations in draft status available to add {resourceName}. Please
-              create or draft an integration first before adding {resourceName}.
+              There are no integrations in {space} status available to add {resourceName}. Please
+              create an integration first before adding {resourceName}.
             </p>
           </EuiCallOut>
         </>

--- a/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/utils/constants.tsx
+++ b/public/pages/CreateDetector/components/DefineDetector/components/DetectionRules/utils/constants.tsx
@@ -7,7 +7,8 @@ import { EuiBasicTableColumn, EuiLink, EuiCompressedSwitch } from '@elastic/eui'
 import { capitalizeFirstLetter } from '../../../../../../../utils/helpers';
 import React, { ReactNode } from 'react';
 import { RuleItem } from '../types/interfaces';
-import { getLogTypeLabel } from '../../../../../../LogTypes/utils/helpers';
+// Wazuh: remove integration title formatting
+// import { getLogTypeLabel } from '../../../../../../LogTypes/utils/helpers';
 
 export type ActiveToggleOnChangeEvent = React.BaseSyntheticEvent<
   React.MouseEvent<HTMLButtonElement>,
@@ -52,7 +53,7 @@ export const getRulesColumns = (
       name: 'Integration',
       width: '10%',
       sortable: true,
-      render: (logType: string) => getLogTypeLabel(logType),
+      render: (logType: string) => logType, // Wazuh: remove integration title formatting
     },
     {
       field: 'library',

--- a/public/pages/Detectors/components/DetectorBasicDetailsView/DetectorBasicDetailsView.tsx
+++ b/public/pages/Detectors/components/DetectorBasicDetailsView/DetectorBasicDetailsView.tsx
@@ -11,7 +11,8 @@ import moment from 'moment';
 import { DEFAULT_EMPTY_DATA, logTypesWithDashboards } from '../../../../utils/constants';
 import { isStandardSource } from '../../../../utils/detectorSource';
 import { Detector } from '../../../../../types';
-import { getLogTypeLabel } from '../../../LogTypes/utils/helpers';
+// Wazuh: remove integration title formatting
+// import { getLogTypeLabel } from '../../../LogTypes/utils/helpers';
 
 export interface DetectorBasicDetailsViewProps {
   detector: Detector;
@@ -75,7 +76,7 @@ export const DetectorBasicDetailsView: React.FC<DetectorBasicDetailsViewProps> =
         { label: 'Detector name', content: name },
         {
           label: 'Integration', // Wazuh: reorganize props
-          content: getLogTypeLabel(detector_type.toLowerCase()),
+          content: detector_type, // Wazuh: remove integration title formatting
         }, // Changed Log Type to Integration by Wazuh
         {
           // Wazuh: add space

--- a/public/pages/Detectors/components/DetectorBasicDetailsView/__snapshots__/DetectorBasicDetailsView.test.tsx.snap
+++ b/public/pages/Detectors/components/DetectorBasicDetailsView/__snapshots__/DetectorBasicDetailsView.test.tsx.snap
@@ -123,7 +123,7 @@ Object {
                     data-test-subj="text-details-group-content-integration"
                     id="some_html_id"
                   >
-                    Detector Type
+                    detector_type
                   </div>
                 </div>
               </div>
@@ -512,7 +512,7 @@ Object {
                   data-test-subj="text-details-group-content-integration"
                   id="some_html_id"
                 >
-                  Detector Type
+                  detector_type
                 </div>
               </div>
             </div>

--- a/public/pages/Detectors/components/WazuhUpdateBasicDetails/WazuhUpdateBasicDetails.tsx
+++ b/public/pages/Detectors/components/WazuhUpdateBasicDetails/WazuhUpdateBasicDetails.tsx
@@ -13,8 +13,6 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiTitle,
-  EuiCompressedComboBox,
-  EuiCompressedFormRow,
 } from '@elastic/eui';
 import { PeriodSchedule } from '../../../../../models/interfaces';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
@@ -40,8 +38,7 @@ import { PageHeader } from '../../../../components/PageHeader/PageHeader';
 import { dataSourceInfo } from '../../../../services/utils/constants';
 import { SpaceSelector } from '../../../../components/SpaceSelector/SpaceSelector';
 import { SpaceTypes } from '../../../../../common/constants';
-import { getLogTypeLabel } from '../../../LogTypes/utils/helpers';
-import { FormFieldHeader } from '../../../../components/FormFieldHeader/FormFieldHeader';
+import { IntegrationComboBox } from '../../../../components/IntegrationComboBox';
 import {
   CreateDetectorRulesState,
   DetectionRules,
@@ -75,9 +72,9 @@ export const WazuhUpdateDetectorBasicDetails: React.FC<WazuhUpdateDetectorBasicD
   const [threatIntelEnabledInitially, setThreatIntelEnabledInitially] = useState(false);
 
   const [selectedSpace, setSelectedSpace] = useState<string>(SpaceTypes.STANDARD.value);
-  const [integrationOptions, setIntegrationOptions] = useState<{ value: string; label: string }[]>(
-    []
-  );
+  const [integrationOptions, setIntegrationOptions] = useState<
+    { id: string; value: string; label: string }[]
+  >([]);
   const [loadingIntegrations, setLoadingIntegrations] = useState(false);
   const [integrationTouched, setIntegrationTouched] = useState(false);
 
@@ -457,36 +454,16 @@ export const WazuhUpdateDetectorBasicDetails: React.FC<WazuhUpdateDetectorBasicD
 
         <EuiSpacer size="m" />
 
-        <EuiCompressedFormRow
-          label={
-            <div>
-              <FormFieldHeader headerTitle="Integration" />
-              <EuiSpacer size="s" />
-            </div>
-          }
-          fullWidth
+        <IntegrationComboBox
+          selectedId={detector.detector_type}
+          options={integrationOptions}
+          isLoading={loadingIntegrations}
           isInvalid={integrationIsInvalid}
           error={integrationIsInvalid ? 'Select an integration.' : undefined}
-        >
-          <EuiCompressedComboBox
-            isInvalid={integrationIsInvalid}
-            placeholder="Select integration"
-            options={integrationOptions}
-            singleSelection={{ asPlainText: true }}
-            isLoading={loadingIntegrations}
-            selectedOptions={
-              detector.detector_type
-                ? [
-                    {
-                      value: detector.detector_type,
-                      label: getLogTypeLabel(detector.detector_type),
-                    },
-                  ]
-                : []
-            }
-            onChange={(e) => onIntegrationChange(e[0]?.value || '')}
-          />
-        </EuiCompressedFormRow>
+          onChange={(e) => onIntegrationChange(e[0]?.value || '')}
+          resourceName="detectors"
+          space={selectedSpace}
+        />
 
         <EuiSpacer size="m" />
 

--- a/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detector/__snapshots__/DetectorDetails.test.tsx.snap
@@ -1478,7 +1478,7 @@ exports[`<DetectorDetails /> spec renders the component 1`] = `
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                               >
-                                Network
+                                network
                               </div>
                             </EuiText>
                           </div>

--- a/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
+++ b/public/pages/Detectors/containers/DetectorDetailsView/__snapshots__/DetectorDetailsView.test.tsx.snap
@@ -719,7 +719,7 @@ exports[`<DetectorDetailsView /> spec renders the component 1`] = `
                               onBlur={[Function]}
                               onFocus={[Function]}
                             >
-                              Detector Type
+                              detector_type
                             </div>
                           </EuiText>
                         </div>

--- a/public/pages/WazuhCreateDetector/components/DefineDetector/components/DetectorType/DetectorType.tsx
+++ b/public/pages/WazuhCreateDetector/components/DefineDetector/components/DetectorType/DetectorType.tsx
@@ -1,29 +1,20 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright Wazuh Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 import React, { Component } from 'react';
-import {
-  EuiCompressedFormRow,
-  EuiSpacer,
-  EuiCompressedComboBox,
-  EuiText,
-  EuiFlexGroup,
-  EuiFlexItem,
-} from '@elastic/eui';
-import { FormFieldHeader } from '../../../../../../components/FormFieldHeader/FormFieldHeader';
+import { EuiCompressedFormRow, EuiSpacer, EuiText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import {
   CreateDetectorRulesState,
   DetectionRules,
 } from '../../../../../CreateDetector/components/DefineDetector/components/DetectionRules/DetectionRules';
 import { RuleItem } from '../../../../../CreateDetector/components/DefineDetector/components/DetectionRules/types/interfaces';
-import ConfigureFieldMapping from '../../../../../CreateDetector/components/ConfigureFieldMapping';
 import { ConfigureFieldMappingProps } from '../../../../../CreateDetector/components/ConfigureFieldMapping/containers/ConfigureFieldMapping';
 import { getIntegrationOptionsBySpace } from '../../../../../../utils/helpers';
-import { getLogTypeLabel } from '../../../../../LogTypes/utils/helpers';
 import { SpaceSelector } from '../../../../../../components/SpaceSelector/SpaceSelector';
 import { SpaceTypes } from '../../../../../../../common/constants';
+import { IntegrationComboBox } from '../../../../../../components/IntegrationComboBox';
 
 interface DetectorTypeProps {
   detectorType: string;
@@ -43,7 +34,7 @@ interface DetectorTypeProps {
 interface DetectorTypeState {
   fieldTouched: boolean;
   selectedSpace: string;
-  detectorTypeOptions: { value: string; label: string }[];
+  detectorTypeOptions: { id: string; value: string; label: string }[];
 }
 
 export default class DetectorType extends Component<DetectorTypeProps, DetectorTypeState> {
@@ -133,36 +124,20 @@ export default class DetectorType extends Component<DetectorTypeProps, DetectorT
         <EuiSpacer size="m" />
 
         <EuiCompressedFormRow
-          label={
-            <div>
-              {/* Replace log type with integration by Wazuh */}
-              <FormFieldHeader headerTitle={'Integration'} />
-              <EuiSpacer size={'s'} />
-            </div>
-          }
           fullWidth={true}
           isInvalid={this.isInvalid()}
           error={this.getErrorMessage()}
         >
-          <EuiCompressedComboBox
-            isInvalid={this.isInvalid()}
-            placeholder="Select integration" // Changed Log Type to Integration by Wazuh
-            data-test-subj={'log_type_dropdown'}
+          <IntegrationComboBox
+            selectedId={detectorType}
             options={detectorTypeOptions}
-            singleSelection={{ asPlainText: true }}
+            isInvalid={this.isInvalid()}
             onChange={(e) => {
               this.onChange(e[0]?.value || '');
             }}
-            selectedOptions={
-              detectorType
-                ? [
-                    {
-                      value: detectorType,
-                      label: getLogTypeLabel(detectorType),
-                    },
-                  ]
-                : []
-            }
+            resourceName="detectors"
+            data-test-subj="integration_dropdown"
+            space={selectedSpace}
           />
         </EuiCompressedFormRow>
 

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -348,15 +348,17 @@ export async function getLogTypeOptions() {
 /**
  * Returns Integration ComboBox options filtered by space and ordered alphabetically.
  * [Wazuh custom] Uses document.metadata?.title for normalized metadata structure (issue #117)
+ * [Wazuh custom] Adds id with the same value to give support to other components.
  */
 
 export async function getIntegrationOptionsBySpace(
   space: string
-): Promise<{ value: string; label: string }[]> {
+): Promise<{ id: string; value: string; label: string }[]> {
   const integrations = await DataStore.integrations.getIntegrations(space);
   // [Wazuh custom] Use metadata object instead of document.title
   return integrations
     .map(({ document: { metadata } }) => ({
+      id: metadata?.title ?? '',
       value: metadata?.title ?? '',
       label: metadata?.title ?? '',
     }))


### PR DESCRIPTION
### Description
This PR removes the usage of `getLogType` label from a number of instances on the project, not all were removed because there are files inherited by OpenSearch and un-used currently by Wazuh, see: [research comment on issue](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/354#issuecomment-4706652126)

To make the fix for `detectors` the `IntegrationComboBox` component was re-used. 

- Updated snapshots.

### Issues Resolved
[#1352](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/354)

### Evidence

<details><summary>Video</summary>


https://github.com/user-attachments/assets/fa6477d2-0f52-49f8-a8a3-c0e2cfd4af14


</details> 

<details><summary>Images</summary>

ComboBox:
<img width="726" height="484" alt="imagen" src="https://github.com/user-attachments/assets/7d87977c-c9c1-47f9-bac1-396e9ee72505" />
<img width="721" height="486" alt="imagen" src="https://github.com/user-attachments/assets/774e60c7-0e16-470c-938e-409fafb03440" />


BasicDetailsView:
<img width="1697" height="495" alt="imagen" src="https://github.com/user-attachments/assets/f51cfdad-ef0f-4ffd-9cdc-bab0183f3317" />

CreateDetector:
<img width="1688" height="367" alt="imagen" src="https://github.com/user-attachments/assets/8402b06d-1523-4e7e-9994-736ca27ab81e" />

EditDetector:
<img width="1856" height="324" alt="imagen" src="https://github.com/user-attachments/assets/6f7a610a-c73e-4be9-beea-dfc1a5ef84ab" />

</details> 

### Tests

- Navigate to `Security analytics` 
- Test every combo box with integrations to validate no title formatting is done (decoders, kvdbs, rules, detectors) on create and edit.
- Validate tables on details view, create detector, edit detectors, and any other table with an `Integration` column to test that no formatting is done.

### Check List
- [x] CHANGELOG.md was updated
- [x] Commits are signed per the DCO using --signoff