### PR TITLE
Add bump-issue-link paramenter to bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -28,6 +28,10 @@ on:
         description: "Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>"
         required: true
         type: string
+      bump-issue-link:
+        description: 'Issue link used in the original bump (required for revert if different from issue-link)'
+        required: false
+        type: string
       id:
         description: "Optional identifier for the run"
         required: false
@@ -154,9 +158,18 @@ jobs:
         id: revert_step
         if: inputs.revert == true
         run: |
+          # 1. Get the current issue number (for the new revert branch/PR)
           ISSUE_NUMBER=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
 
-          BUMP_BRANCH="enhancement/wqa${ISSUE_NUMBER}-bump-${{ github.ref_name }}"
+          # 2. Get the issue number from the original bump (if provided; otherwise, defaults to the current one)
+          if [ -n "${{ inputs.bump-issue-link }}" ]; then
+            BUMP_ISSUE_NUMBER=$(echo "${{ inputs.bump-issue-link }}" | awk -F'/' '{print $NF}')
+          else
+            BUMP_ISSUE_NUMBER=$ISSUE_NUMBER
+          fi
+
+          # 3. Search for the original bump branch using the obtained BUMP ISSUE number
+          BUMP_BRANCH="enhancement/wqa${BUMP_ISSUE_NUMBER}-bump-${{ github.ref_name }}"
 
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
@@ -172,6 +185,7 @@ jobs:
 
           git revert -m 1 $MERGE_COMMIT --no-commit
 
+          # Remove the files to prevent them from being included in the revert commit
           git checkout HEAD -- VERSION.json 2>/dev/null || true
           git checkout HEAD -- CHANGELOG.md 2>/dev/null || true
           git checkout HEAD -- package.json 2>/dev/null || true


### PR DESCRIPTION
### Description
This pull request adds the `bump-issue-link` parameter to the bumper workflow that allows revert the changes from a different bump PR.

### Issues Resolved
#352

### Evidences

- Bump: https://github.com/Desvelao/wazuh-dashboard-security-analytics/actions/runs/27609843635
- Revert: https://github.com/Desvelao/wazuh-dashboard-security-analytics/actions/runs/27609900575
> https://github.com/Desvelao/wazuh-dashboard-security-analytics/actions/runs/27609900575/job/81631349828#step:11:51

### Check List
- [x] Commits are signed per the DCO using --signoff
