### PR TITLE
Change public imports to common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the Wazuh ML Commons project will be documented in this f
 - Added clear space action to the Overview actions button [#186](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/186) 
 - Added modifiers in the dropdown inside the rule creation and edition form [#259](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/259)
 - Added URL-based rule navigation from Log Test detection results [#308](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/308)
--  Added `opensearch_security_analytics.disabledSettings` configuration to hide specific settings in the UI about Index discarded/unclassified events [#350](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/350)
+- Added `opensearch_security_analytics.disabledSettings` configuration to hide specific settings in the UI about Index discarded/unclassified events [#350](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/350) [#375](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/375)
 - Added date formatter that respects the dateFormat advanced setting [#362](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/362)
 
 ### Changed

--- a/common/helpers.ts
+++ b/common/helpers.ts
@@ -6,7 +6,7 @@
 import _ from 'lodash';
 import { DEFAULT_METRICS_COUNTER } from '../server/utils/constants';
 import { MetricsCounter, PartialMetricsCounter, PromoteSpaces, Space } from '../types';
-import { SecurityAnalyticsPluginConfigType } from '../public/models/types';
+import { SecurityAnalyticsPluginConfigType } from '../config';
 import { Get, Set } from '../../../src/plugins/opensearch_dashboards_utils/common';
 
 // Wazuh

--- a/common/helpers.ts
+++ b/common/helpers.ts
@@ -11,30 +11,6 @@ import { Get, Set } from '../../../src/plugins/opensearch_dashboards_utils/commo
 
 // Wazuh
 import { AllowedActionsBySpace, SpaceTypes, UserSpacesOrder } from './constants';
-import { getCapabilities } from '../public/services/utils/constants';
-
-export const UI_DISABLED_SETTINGS_IDS = {
-  INDEX_DISCARDED_EVENTS: 'index-discarded-events',
-  INDEX_UNCLASSIFIED_EVENTS: 'index-unclassified-events',
-  INDEX_RAW_EVENTS: 'index-raw-events',
-} as const;
-
-export type UIDisabledSettingId =
-  (typeof UI_DISABLED_SETTINGS_IDS)[keyof typeof UI_DISABLED_SETTINGS_IDS];
-
-export const isUiSettingDisabled = (settingId: UIDisabledSettingId): boolean => {
-  const caps = getCapabilities()?.securityAnalytics;
-
-  if (!caps) return false;
-
-  const capabilityMap: Record<UIDisabledSettingId, string> = {
-    [UI_DISABLED_SETTINGS_IDS.INDEX_DISCARDED_EVENTS]: 'showIndexDiscardedEvents',
-    [UI_DISABLED_SETTINGS_IDS.INDEX_UNCLASSIFIED_EVENTS]: 'showIndexUnclassifiedEvents',
-    [UI_DISABLED_SETTINGS_IDS.INDEX_RAW_EVENTS]: 'showIndexRawEvents',
-  };
-
-  return caps[capabilityMap[settingId]] === false;
-};
 
 export function aggregateMetrics(
   metrics: PartialMetricsCounter,

--- a/config.ts
+++ b/config.ts
@@ -8,7 +8,6 @@ import { schema, TypeOf } from '@osd/config-schema';
 export const DISABLED_SETTING_IDS = [
   'index-discarded-events',
   'index-unclassified-events',
-  'index-raw-events',
 ] as const;
 
 export type DisabledSettingId = (typeof DISABLED_SETTING_IDS)[number];

--- a/public/models/types.ts
+++ b/public/models/types.ts
@@ -6,10 +6,3 @@
 import { RulesSharedState } from './interfaces';
 
 export type CreateDetectorRulesOptions = Pick<RulesSharedState, 'rulesOptions'>['rulesOptions'];
-
-export interface SecurityAnalyticsPluginConfigType {
-  enabled: boolean;
-
-  uxTelemetryInterval: number;
-  disabledSettings: string[];
-}

--- a/public/pages/Integrations/components/EditPolicy.tsx
+++ b/public/pages/Integrations/components/EditPolicy.tsx
@@ -33,12 +33,8 @@ import { FormFieldArray } from '../../../components/FormFieldArray';
 import { INTEGRATION_AUTHOR_REGEX, validateName } from '../../../utils/validation';
 import { buildDecodersSearchQuery } from '../../Decoders/utils/constants';
 import { SPACE_ACTIONS } from '../../../../common/constants';
-import {
-  actionIsAllowedOnSpace,
-  getSpaceTypeLabel,
-  isUiSettingDisabled,
-  UI_DISABLED_SETTINGS_IDS,
-} from '../../../../common/helpers';
+import { actionIsAllowedOnSpace, getSpaceTypeLabel } from '../../../../common/helpers';
+import { UI_DISABLED_SETTINGS_IDS, isUiSettingDisabled } from '../../../utils/helpers';
 import { ALLOWED_ENRICHMENTS, ENRICHMENT_LABELS, EnrichmentType } from '../constants/enrichments';
 
 const DECODER_SEARCH_SIZE = 25;

--- a/public/pages/Integrations/components/PolicyInfoCard.tsx
+++ b/public/pages/Integrations/components/PolicyInfoCard.tsx
@@ -22,7 +22,7 @@ import { NotificationsStart } from 'opensearch-dashboards/public';
 import { ENRICHMENT_LABELS, EnrichmentType } from '../constants/enrichments';
 import { formatIntegrationMetadataDate } from '../utils/helpers';
 import { withPolicyGuard } from './PolicyGuard';
-import { isUiSettingDisabled, UI_DISABLED_SETTINGS_IDS } from '../../../../common/helpers';
+import { UI_DISABLED_SETTINGS_IDS, isUiSettingDisabled } from '../../../utils/helpers';
 
 const truncateStyle: React.CSSProperties = {
   display: '-webkit-box',

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -96,7 +96,6 @@ import { getCapabilities } from '../services/utils/constants';
 export const UI_DISABLED_SETTINGS_IDS = {
   INDEX_DISCARDED_EVENTS: 'index-discarded-events',
   INDEX_UNCLASSIFIED_EVENTS: 'index-unclassified-events',
-  INDEX_RAW_EVENTS: 'index-raw-events',
 } as const;
 
 export type UIDisabledSettingId =
@@ -110,7 +109,6 @@ export const isUiSettingDisabled = (settingId: UIDisabledSettingId): boolean => 
   const capabilityMap: Record<UIDisabledSettingId, string> = {
     [UI_DISABLED_SETTINGS_IDS.INDEX_DISCARDED_EVENTS]: 'showIndexDiscardedEvents',
     [UI_DISABLED_SETTINGS_IDS.INDEX_UNCLASSIFIED_EVENTS]: 'showIndexUnclassifiedEvents',
-    [UI_DISABLED_SETTINGS_IDS.INDEX_RAW_EVENTS]: 'showIndexRawEvents',
   };
 
   return caps[capabilityMap[settingId]] === false;

--- a/public/utils/helpers.tsx
+++ b/public/utils/helpers.tsx
@@ -90,6 +90,33 @@ import { DataSourceAttributes } from '../../../../src/plugins/data_source/common
 import { ISearchStart } from '../../../../src/plugins/data/public';
 import LogTestService from '../services/LogTestService';
 
+// Wazuh: hide settings on the UI
+import { getCapabilities } from '../services/utils/constants';
+
+export const UI_DISABLED_SETTINGS_IDS = {
+  INDEX_DISCARDED_EVENTS: 'index-discarded-events',
+  INDEX_UNCLASSIFIED_EVENTS: 'index-unclassified-events',
+  INDEX_RAW_EVENTS: 'index-raw-events',
+} as const;
+
+export type UIDisabledSettingId =
+  (typeof UI_DISABLED_SETTINGS_IDS)[keyof typeof UI_DISABLED_SETTINGS_IDS];
+
+export const isUiSettingDisabled = (settingId: UIDisabledSettingId): boolean => {
+  const caps = getCapabilities()?.securityAnalytics;
+
+  if (!caps) return false;
+
+  const capabilityMap: Record<UIDisabledSettingId, string> = {
+    [UI_DISABLED_SETTINGS_IDS.INDEX_DISCARDED_EVENTS]: 'showIndexDiscardedEvents',
+    [UI_DISABLED_SETTINGS_IDS.INDEX_UNCLASSIFIED_EVENTS]: 'showIndexUnclassifiedEvents',
+    [UI_DISABLED_SETTINGS_IDS.INDEX_RAW_EVENTS]: 'showIndexRawEvents',
+  };
+
+  return caps[capabilityMap[settingId]] === false;
+};
+// Wazuh: end block
+
 export const parseStringsToOptions = (strings: string[]) => {
   return strings.map((str) => ({ id: str, label: str }));
 };

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -144,7 +144,6 @@ export class SecurityAnalyticsPlugin implements Plugin<
       securityAnalytics: {
         showIndexDiscardedEvents: !config.disabledSettings.includes('index-discarded-events'),
         showIndexUnclassifiedEvents: !config.disabledSettings.includes('index-unclassified-events'),
-        showIndexRawEvents: !config.disabledSettings.includes('index-raw-events'),
       },
     }));
 


### PR DESCRIPTION
### Description
This PR fixes an error generated by the PR: #350, an import on common from public was generating an error during the nightly execution.

### Other changes
- Removed deprecated `index-raw-events` deprecated setting.

### Issues Resolved
#342 
[#1387 (wazuh-dashboard)](https://github.com/wazuh/wazuh-dashboard/issues/1387)

### Evidence

https://github.com/user-attachments/assets/1f3c8755-8886-4d4c-a2ae-f76df1fe4a88

```
opensearch_security_analytics.disabledSettings:
  - index-discarded-events
  - index-unclassified-events
```

### Tests
- Navigate to `Security analytics > Overview` and edit the space (draft or standard) to verify the settings appear.
- Add the configuration from evidence to `opensearch_dashboard.yml` and validate the settings don't appear on the edit space.
- Leave only one of the options (e.g: `index-discarded-events`) and validate it does not appear on the UI.

### Check List
- [X] Commits are signed per the DCO using --signoff