### PR TITLE
Change bumper_repository workflows merge type

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -5,27 +5,27 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Target version (e.g. 4.12.0)"
-        default: ""
+        description: 'Target version (e.g. 4.12.0)'
+        default: ''
         required: false
         type: string
       stage:
-        description: "Version stage (e.g. alpha0)"
-        default: ""
+        description: 'Version stage (e.g. alpha0)'
+        default: ''
         required: false
         type: string
       tag:
-        description: "Change branches references to tag-like references (e.g. v4.12.0-alpha7)"
+        description: 'Change branches references to tag-like references (e.g. v4.12.0-alpha7)'
         default: false
         required: false
         type: boolean
       set_as_main:
-        description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
+        description: 'Enable main branch mode: bump version values only, keep branch references pointing to main'
         required: false
         type: boolean
         default: false
       issue-link:
-        description: "Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>"
+        description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
         required: true
         type: string
       bump-issue-link:
@@ -33,11 +33,11 @@ on:
         required: false
         type: string
       id:
-        description: "Optional identifier for the run"
+        description: 'Optional identifier for the run'
         required: false
         type: string
       revert:
-        description: "Set to true to revert the bump changes applied for this issue"
+        description: 'Set to true to revert the bump changes applied for this issue'
         default: false
         required: false
         type: boolean

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Merge pull request
         if: (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
 
       - name: Show logs
         if: inputs.revert != true

--- a/.github/workflows/6_bumper_repository.yml
+++ b/.github/workflows/6_bumper_repository.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Merge pull request
         if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
 
       - name: Show logs
         if: inputs.revert != true


### PR DESCRIPTION
## Description

`5_bumper_repository.yml` and `6_bumper_repository.yml` currently merge their generated bump PRs with `gh pr merge --merge --admin`, which creates a merge commit — inconsistent with this repo's squash-merge convention for single-purpose PRs. This PR switches both to `--squash --admin`.

Closes https://github.com/wazuh/wazuh-dashboard/issues/1459

## Proposed Changes

- `.github/workflows/5_bumper_repository.yml`: `gh pr merge ... --merge --admin` → `gh pr merge ... --squash --admin`.
- `.github/workflows/6_bumper_repository.yml`: same change.

### Results and Evidence

`git diff origin/5.0.0..HEAD` shows exactly 2 files changed, 2 lines total:

```diff
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -220,7 +220,7 @@
       - name: Merge pull request
         if: (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin

--- a/.github/workflows/6_bumper_repository.yml
+++ b/.github/workflows/6_bumper_repository.yml
@@ -187,7 +187,7 @@
       - name: Merge pull request
         if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
```

### Artifacts Affected

- `.github/workflows/5_bumper_repository.yml`, `6_bumper_repository.yml` (CI workflows, no runtime/build artifact)

### Configuration Changes

None (CI merge-strategy flag only).

### Documentation Updates

None.

### Tests Introduced

None. Non-executable CLI flag change in 2 GitHub Actions steps — no unit-testable logic exists. Verified manually via direct diff/read inspection against `origin/5.0.0`.

### How to Test

1. Confirm both `5_` and `6_bumper_repository.yml` pass `--squash --admin` (not `--merge --admin`).
2. (Optional, real effect only observable in CI) On the next bumper run on this branch, confirm the generated bump PR is merged via squash rather than a merge commit.

### Review Checklist

- [ ] All tests pass
  - [ ] `yarn test:jest` — N/A, no JS/TS changed
- [ ] New functionality includes testing. — N/A, no executable logic changed
- [ ] New functionality has been documented. — N/A
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md) — Skipped: internal CI tooling, no user-facing impact
- [x] Commits are signed per the DCO using --signoff
