### PR TITLE
Improve repository bumper error handling

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -174,11 +174,14 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> "$GITHUB_OUTPUT"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          echo "pr_found=true" >> "$GITHUB_OUTPUT"
           echo "Original PR found: #$PR_NUMBER"
 
           MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
@@ -197,6 +200,17 @@ jobs:
             git commit -m "feat: revert ${{ github.ref_name }} references"
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: 'Result: original bump pull request not found'
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: 'Result: no changes to commit'
+        if: >-
+          (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."
 
       - name: Push changes
         if: (inputs.revert != true && steps.bump_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')


### PR DESCRIPTION
## Description

Closes #436

The release orchestration in `wazuh-qa-automation` now tells apart a bump that
**failed** from a bump that **had nothing to do**. Today
`.github/workflows/5_bumper_repository.yml` ends with the `failure` conclusion
in both harmless cases, so the orchestrator can't tell them apart from a real
failure.

## Proposed Changes

- On a revert run, when the original bump pull request is not found, the
  `Revert references (Revert)` step no longer runs `exit 1`; it now reports
  `pr_found=false` / `has_changes=false` and exits `0`, skipping the rest of
  the steps.
- `Push changes`, `Create pull request` and `Merge pull request` stay skipped
  in both the "PR not found" and "no changes" cases (already correctly
  conditioned on the `has_changes` outputs).
- Two new steps report the outcome with the exact names expected by the
  orchestrator: `Result: original bump pull request not found` and
  `Result: no changes to commit`.

### Results and Evidence

<!-- Attach the links of the four validation runs (revert/no-PR, bump/no-changes, normal bump, normal revert) here. -->

### Artifacts Affected

None — CI workflow only.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

N/A — CI workflow change; validated by running the workflow on the release
branch for the four scenarios described in the issue (see Results and
Evidence).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)