### PR TITLE
MITRE ATT&CK rule definition silent validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 | Issue | Comment |
 | ----- | ------- |
-| [#9](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/9) | Fixed YAML Editor when creating or editing detection rules |
+| [#9](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/9) [#446](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/446) | Fixed YAML Editor when creating or editing detection rules |
 | [#44](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/44) | Fixed detection rule editor causing blank screen |
 | [#315](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/315) | Fixed rule JSON viewer showing the detection field as a YAML string instead of a structured object |
 | [#116](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/116) | Fixed data source didn't include data stream aliases for detector creation |

--- a/public/pages/WazuhRules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/WazuhRules/components/RuleEditor/RuleEditorForm.tsx
@@ -87,7 +87,11 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
   validateOnMount,
   subtitleData,
 }) => {
-  const [selectedEditorType, setSelectedEditorType] = useState('visual');
+  // A block the visual editor cannot show opens in the YAML editor instead, so simply
+  // opening a rule never discards it.
+  const [selectedEditorType, setSelectedEditorType] = useState(
+    parseMitreYmlWithErrors(initialValue.mitre).errors.length ? 'yaml' : 'visual'
+  );
   const [isDetectionInvalid, setIsDetectionInvalid] = useState(false);
   const [integrationId, setIntegrationId] = useState('');
 
@@ -188,11 +192,6 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
       }}
     >
       {(props) => {
-        // Derived, not stored: the raw YAML in `values.mitre` is the single source of truth.
-        // The messages themselves name YAML paths, so they are only shown in the YAML
-        // editor; here it is enough to say the data is invalid and where to look.
-        const hasMitreErrors = parseMitreYmlWithErrors(props.values.mitre).errors.length > 0;
-
         const onIntegrationCreateSuccess = (newOption: {
           id: string;
           value: string;
@@ -232,7 +231,17 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                 legend="This is editor type selector"
                 options={editorTypes}
                 idSelected={selectedEditorType}
-                onChange={(id) => setSelectedEditorType(id)}
+                onChange={(id) => {
+                  // The visual editor can only hold valid data, so switching to it clears
+                  // a block it cannot show rather than leaving the two editors disagreeing.
+                  if (
+                    id === 'visual' &&
+                    parseMitreYmlWithErrors(props.values.mitre).errors.length
+                  ) {
+                    props.setFieldValue('mitre', '');
+                  }
+                  setSelectedEditorType(id);
+                }}
               />
 
               <EuiSpacer size="xl" />
@@ -548,8 +557,8 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                       <>
                         MITRE ATT&CK <i>- optional</i>
                         <EuiText size="xs" color={props.errors.mitre ? 'danger' : 'subdued'}>
-                          {hasMitreErrors
-                            ? 'This MITRE ATT&CK data is not valid, so it cannot all be shown here. Check the YAML editor for the details, or fill in the fields below to replace it.'
+                          {props.errors.mitre
+                            ? 'Some entries are incomplete. Both ID and name are required.'
                             : 'Map this rule to MITRE ATT&CK tactics, techniques and subtechniques.'}
                         </EuiText>
                       </>

--- a/public/pages/WazuhRules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/WazuhRules/components/RuleEditor/RuleEditorForm.tsx
@@ -10,7 +10,6 @@ import {
   EuiBottomBar,
   EuiButton,
   EuiButtonEmpty,
-  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -190,7 +189,9 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
     >
       {(props) => {
         // Derived, not stored: the raw YAML in `values.mitre` is the single source of truth.
-        const mitreErrors = parseMitreYmlWithErrors(props.values.mitre).errors;
+        // The messages themselves name YAML paths, so they are only shown in the YAML
+        // editor; here it is enough to say the data is invalid and where to look.
+        const hasMitreErrors = parseMitreYmlWithErrors(props.values.mitre).errors.length > 0;
 
         const onIntegrationCreateSuccess = (newOption: {
           id: string;
@@ -547,10 +548,8 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                       <>
                         MITRE ATT&CK <i>- optional</i>
                         <EuiText size="xs" color={props.errors.mitre ? 'danger' : 'subdued'}>
-                          {mitreErrors.length
-                            ? `The MITRE ATT&CK block has ${mitreErrors.length} problem${
-                                mitreErrors.length > 1 ? 's' : ''
-                              }. Expand to see the details.`
+                          {hasMitreErrors
+                            ? 'This MITRE ATT&CK data is not valid, so it cannot all be shown here. Check the YAML editor for the details, or fill in the fields below to replace it.'
                             : 'Map this rule to MITRE ATT&CK tactics, techniques and subtechniques.'}
                         </EuiText>
                       </>
@@ -558,23 +557,6 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                     paddingSize="l"
                   >
                     <EuiSpacer size="s" />
-                    {!!mitreErrors.length && (
-                      <>
-                        <EuiCallOut
-                          size="s"
-                          color="danger"
-                          title="Fix the MITRE ATT&CK block in the YAML editor, or replace it using the fields below."
-                          data-test-subj="mitre_structural_errors"
-                        >
-                          <ul>
-                            {mitreErrors.map((error, i) => (
-                              <li key={i}>{error}</li>
-                            ))}
-                          </ul>
-                        </EuiCallOut>
-                        <EuiSpacer size="s" />
-                      </>
-                    )}
                     <MitreVisualEditor
                       mitreYml={props.values.mitre}
                       onChange={(yml) => props.setFieldValue('mitre', yml)}

--- a/public/pages/WazuhRules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/WazuhRules/components/RuleEditor/RuleEditorForm.tsx
@@ -205,42 +205,191 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
         };
 
         return (
-        <Form>
-          <EuiPanel className={'rule-editor-form'} style={{ paddingBottom: '60px' }}>
-            <PageHeader appDescriptionControls={subtitleData ? [subtitleData] : undefined}>
-              <EuiText size="s">
-                <h1>{title}</h1>
-              </EuiText>
-              {subtitleData && (
-                <>
-                  <EuiText size="s" color="subdued">
-                    {subtitleData.description}
-                  </EuiText>
-                  {subtitleData.links && (
-                    <EuiText size="s">
-                      <EuiLink href={subtitleData.links.href} target="_blank">
-                        {subtitleData.links.label}
-                      </EuiLink>
+          <Form>
+            <EuiPanel className={'rule-editor-form'} style={{ paddingBottom: '60px' }}>
+              <PageHeader appDescriptionControls={subtitleData ? [subtitleData] : undefined}>
+                <EuiText size="s">
+                  <h1>{title}</h1>
+                </EuiText>
+                {subtitleData && (
+                  <>
+                    <EuiText size="s" color="subdued">
+                      {subtitleData.description}
                     </EuiText>
+                    {subtitleData.links && (
+                      <EuiText size="s">
+                        <EuiLink href={subtitleData.links.href} target="_blank">
+                          {subtitleData.links.label}
+                        </EuiLink>
+                      </EuiText>
+                    )}
+                  </>
+                )}
+                <EuiSpacer />
+              </PageHeader>
+              <EuiButtonGroup
+                data-test-subj="change-editor-type"
+                legend="This is editor type selector"
+                options={editorTypes}
+                idSelected={selectedEditorType}
+                onChange={(id) => setSelectedEditorType(id)}
+              />
+
+              <EuiSpacer size="xl" />
+
+              {selectedEditorType === 'yaml' && (
+                <>
+                  {mode === 'create' && (
+                    <>
+                      <IntegrationComboBox
+                        options={integrationOptions}
+                        selectedId={integrationId}
+                        isLoading={loadingIntegrations}
+                        data-test-subj={'rule_integration_dropdown'}
+                        resourceName="rules"
+                        isInvalid={
+                          (validateOnMount || props.touched.integration) &&
+                          !!props.errors?.integration
+                        }
+                        error={props.errors.integration}
+                        notifications={notifications}
+                        onCreateSuccess={onIntegrationCreateSuccess}
+                        onChange={(selected) => {
+                          const option = selected[0] ?? null;
+                          setIntegrationId(option?.id ?? '');
+                          props.setFieldValue(
+                            'integration',
+                            option?.value ?? option?.label ?? '',
+                            true
+                          );
+                          props.setFieldTouched('integration', true, false);
+                        }}
+                      />
+                      <EuiSpacer size="xl" />
+                    </>
                   )}
+                  <YamlRuleEditorComponent
+                    rule={mapFormToRule(props.values)}
+                    isInvalid={Object.keys(props.errors).length > 0}
+                    errors={Object.values(props.errors).flatMap((v) =>
+                      typeof v === 'string'
+                        ? [v]
+                        : v && typeof v === 'object'
+                        ? Object.values(v).filter((x) => typeof x === 'string')
+                        : []
+                    )}
+                    change={(e) => {
+                      const formState = mapRuleToForm(e);
+                      props.setValues(formState);
+                    }}
+                  />
                 </>
               )}
-              <EuiSpacer />
-            </PageHeader>
-            <EuiButtonGroup
-              data-test-subj="change-editor-type"
-              legend="This is editor type selector"
-              options={editorTypes}
-              idSelected={selectedEditorType}
-              onChange={(id) => setSelectedEditorType(id)}
-            />
+              <FormSubmissionErrorToastNotification notifications={notifications} />
+              {selectedEditorType === 'visual' && (
+                <>
+                  <EuiTitle>
+                    <EuiText size="s">
+                      <h2>Rule overview</h2>
+                    </EuiText>
+                  </EuiTitle>
 
-            <EuiSpacer size="xl" />
+                  <EuiSpacer />
 
-            {selectedEditorType === 'yaml' && (
-              <>
-                {mode === 'create' && (
-                  <>
+                  <EuiCompressedFormRow
+                    label={
+                      <EuiText size={'s'}>
+                        <strong>Rule name</strong>
+                      </EuiText>
+                    }
+                    isInvalid={
+                      (validateOnMount || props.touched.metadata?.title) &&
+                      !!props.errors?.metadata?.title
+                    }
+                    error={props.errors?.metadata?.title}
+                    helpText={detectionRuleNameError}
+                  >
+                    <EuiCompressedFieldText
+                      isInvalid={
+                        (validateOnMount || props.touched.metadata?.title) &&
+                        !!props.errors?.metadata?.title
+                      }
+                      placeholder="My custom rule"
+                      data-test-subj={'rule_name_field'}
+                      onChange={(e) => {
+                        props.handleChange('metadata.title')(e);
+                      }}
+                      onBlur={props.handleBlur('metadata.title')}
+                      value={props.values.metadata.title}
+                    />
+                  </EuiCompressedFormRow>
+
+                  <EuiSpacer size={'m'} />
+
+                  <EuiCompressedFormRow
+                    label={
+                      <EuiText size={'s'}>
+                        <strong>Description </strong>
+                        <i>- optional</i>
+                      </EuiText>
+                    }
+                    isInvalid={
+                      (validateOnMount || props.touched.metadata?.description) &&
+                      !!props.errors?.metadata?.description
+                    }
+                    error={props.errors?.metadata?.description}
+                  >
+                    <EuiCompressedTextArea
+                      data-test-subj={'rule_description_field'}
+                      onChange={(e) => {
+                        props.handleChange('metadata.description')(e.target.value);
+                      }}
+                      onBlur={props.handleBlur('metadata.description')}
+                      value={props.values.metadata.description}
+                      placeholder={'Detects ...'}
+                    />
+                  </EuiCompressedFormRow>
+
+                  <EuiSpacer size={'m'} />
+
+                  <EuiCompressedFormRow
+                    label={
+                      <EuiText size={'s'}>
+                        <strong>Author</strong>
+                      </EuiText>
+                    }
+                    helpText="Combine multiple authors separated with a comma"
+                    isInvalid={
+                      (validateOnMount || props.touched.metadata?.author) &&
+                      !!props.errors?.metadata?.author
+                    }
+                    error={props.errors?.metadata?.author}
+                  >
+                    <EuiCompressedFieldText
+                      isInvalid={
+                        (validateOnMount || props.touched.metadata?.author) &&
+                        !!props.errors?.metadata?.author
+                      }
+                      placeholder="Enter author name"
+                      data-test-subj={'rule_author_field'}
+                      onChange={(e) => {
+                        props.handleChange('metadata.author')(e);
+                      }}
+                      onBlur={props.handleBlur('metadata.author')}
+                      value={props.values.metadata.author}
+                    />
+                  </EuiCompressedFormRow>
+
+                  <EuiSpacer size={'xl'} />
+
+                  <EuiTitle>
+                    <EuiText size="s">
+                      <h2>Details</h2>
+                    </EuiText>
+                  </EuiTitle>
+
+                  <EuiSpacer />
+                  {mode === 'create' ? (
                     <IntegrationComboBox
                       options={integrationOptions}
                       selectedId={integrationId}
@@ -265,536 +414,391 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                         props.setFieldTouched('integration', true, false);
                       }}
                     />
-                    <EuiSpacer size="xl" />
-                  </>
-                )}
-                <YamlRuleEditorComponent
-                  rule={mapFormToRule(props.values)}
-                  isInvalid={Object.keys(props.errors).length > 0}
-                  errors={Object.values(props.errors).flatMap((v) =>
-                    typeof v === 'string'
-                      ? [v]
-                      : v && typeof v === 'object'
-                      ? Object.values(v).filter((x) => typeof x === 'string')
-                      : []
+                  ) : (
+                    <EuiCompressedFormRow
+                      label={
+                        <EuiText size={'s'}>
+                          <strong>Integration</strong>
+                        </EuiText>
+                      }
+                    >
+                      <EuiCompressedFieldText
+                        value={props.values.integration}
+                        readOnly
+                        data-test-subj={'rule_integration_field'}
+                      />
+                    </EuiCompressedFormRow>
                   )}
-                  change={(e) => {
-                    const formState = mapRuleToForm(e);
-                    props.setValues(formState);
-                  }}
-                />
-              </>
-            )}
-            <FormSubmissionErrorToastNotification notifications={notifications} />
-            {selectedEditorType === 'visual' && (
-              <>
-                <EuiTitle>
-                  <EuiText size="s">
-                    <h2>Rule overview</h2>
-                  </EuiText>
-                </EuiTitle>
 
-                <EuiSpacer />
+                  <EuiSpacer />
 
-                <EuiCompressedFormRow
-                  label={
-                    <EuiText size={'s'}>
-                      <strong>Rule name</strong>
-                    </EuiText>
-                  }
-                  isInvalid={
-                    (validateOnMount || props.touched.metadata?.title) &&
-                    !!props.errors?.metadata?.title
-                  }
-                  error={props.errors?.metadata?.title}
-                  helpText={detectionRuleNameError}
-                >
-                  <EuiCompressedFieldText
-                    isInvalid={
-                      (validateOnMount || props.touched.metadata?.title) &&
-                      !!props.errors?.metadata?.title
-                    }
-                    placeholder="My custom rule"
-                    data-test-subj={'rule_name_field'}
-                    onChange={(e) => {
-                      props.handleChange('metadata.title')(e);
-                    }}
-                    onBlur={props.handleBlur('metadata.title')}
-                    value={props.values.metadata.title}
-                  />
-                </EuiCompressedFormRow>
-
-                <EuiSpacer size={'m'} />
-
-                <EuiCompressedFormRow
-                  label={
-                    <EuiText size={'s'}>
-                      <strong>Description </strong>
-                      <i>- optional</i>
-                    </EuiText>
-                  }
-                  isInvalid={
-                    (validateOnMount || props.touched.metadata?.description) &&
-                    !!props.errors?.metadata?.description
-                  }
-                  error={props.errors?.metadata?.description}
-                >
-                  <EuiCompressedTextArea
-                    data-test-subj={'rule_description_field'}
-                    onChange={(e) => {
-                      props.handleChange('metadata.description')(e.target.value);
-                    }}
-                    onBlur={props.handleBlur('metadata.description')}
-                    value={props.values.metadata.description}
-                    placeholder={'Detects ...'}
-                  />
-                </EuiCompressedFormRow>
-
-                <EuiSpacer size={'m'} />
-
-                <EuiCompressedFormRow
-                  label={
-                    <EuiText size={'s'}>
-                      <strong>Author</strong>
-                    </EuiText>
-                  }
-                  helpText="Combine multiple authors separated with a comma"
-                  isInvalid={
-                    (validateOnMount || props.touched.metadata?.author) &&
-                    !!props.errors?.metadata?.author
-                  }
-                  error={props.errors?.metadata?.author}
-                >
-                  <EuiCompressedFieldText
-                    isInvalid={
-                      (validateOnMount || props.touched.metadata?.author) &&
-                      !!props.errors?.metadata?.author
-                    }
-                    placeholder="Enter author name"
-                    data-test-subj={'rule_author_field'}
-                    onChange={(e) => {
-                      props.handleChange('metadata.author')(e);
-                    }}
-                    onBlur={props.handleBlur('metadata.author')}
-                    value={props.values.metadata.author}
-                  />
-                </EuiCompressedFormRow>
-
-                <EuiSpacer size={'xl'} />
-
-                <EuiTitle>
-                  <EuiText size="s">
-                    <h2>Details</h2>
-                  </EuiText>
-                </EuiTitle>
-
-                <EuiSpacer />
-                {mode === 'create' ? (
-                  <IntegrationComboBox
-                    options={integrationOptions}
-                    selectedId={integrationId}
-                    isLoading={loadingIntegrations}
-                    data-test-subj={'rule_integration_dropdown'}
-                    resourceName="rules"
-                    isInvalid={
-                      (validateOnMount || props.touched.integration) && !!props.errors?.integration
-                    }
-                    error={props.errors.integration}
-                    notifications={notifications}
-                    onCreateSuccess={onIntegrationCreateSuccess}
-                    onChange={(selected) => {
-                      const option = selected[0] ?? null;
-                      setIntegrationId(option?.id ?? '');
-                      props.setFieldValue(
-                        'integration',
-                        option?.value ?? option?.label ?? '',
-                        true
-                      );
-                      props.setFieldTouched('integration', true, false);
-                    }}
-                  />
-                ) : (
                   <EuiCompressedFormRow
                     label={
                       <EuiText size={'s'}>
-                        <strong>Integration</strong>
+                        <strong>Rule level (severity)</strong>
+                      </EuiText>
+                    }
+                    isInvalid={(validateOnMount || props.touched.level) && !!props.errors?.level}
+                    error={props.errors.level}
+                  >
+                    <EuiCompressedComboBox
+                      isInvalid={(validateOnMount || props.touched.level) && !!props.errors?.level}
+                      placeholder="Select a rule level"
+                      data-test-subj={'rule_severity_dropdown'}
+                      options={ruleSeverity.map(({ name, value }) => ({ label: name, value }))}
+                      singleSelection={{ asPlainText: true }}
+                      onChange={(e) => props.handleChange('level')(e[0]?.value ?? '')}
+                      onBlur={props.handleBlur('level')}
+                      selectedOptions={
+                        props.values.level
+                          ? [
+                              {
+                                value: props.values.level,
+                                label: getSeverityLabel(props.values.level),
+                              },
+                            ]
+                          : []
+                      }
+                    />
+                  </EuiCompressedFormRow>
+
+                  <EuiSpacer />
+
+                  <EuiCompressedFormRow
+                    label={
+                      <EuiText size={'s'}>
+                        <strong>Rule Status</strong>
+                      </EuiText>
+                    }
+                    isInvalid={(validateOnMount || props.touched.status) && !!props.errors?.status}
+                    error={props.errors.status}
+                  >
+                    <EuiCompressedComboBox
+                      isInvalid={
+                        (validateOnMount || props.touched.status) && !!props.errors?.status
+                      }
+                      placeholder="Select a rule status"
+                      data-test-subj={'rule_status_dropdown'}
+                      options={ruleStatus.map((type: string) => ({ value: type, label: type }))}
+                      singleSelection={{ asPlainText: true }}
+                      onChange={(e) => props.handleChange('status')(e[0]?.value ?? '')}
+                      onBlur={props.handleBlur('status')}
+                      selectedOptions={
+                        props.values.status
+                          ? [{ value: props.values.status, label: String(props.values.status) }]
+                          : []
+                      }
+                    />
+                  </EuiCompressedFormRow>
+
+                  <EuiSpacer />
+
+                  <EuiCompressedFormRow
+                    label={
+                      <EuiText size={'s'}>
+                        <strong>Enabled</strong>
                       </EuiText>
                     }
                   >
-                    <EuiCompressedFieldText
-                      value={props.values.integration}
-                      readOnly
-                      data-test-subj={'rule_integration_field'}
+                    <EuiSwitch
+                      label={props.values.enabled ? 'Rule is enabled' : 'Rule is disabled'}
+                      checked={props.values.enabled}
+                      onChange={(e) => props.setFieldValue('enabled', e.target.checked)}
+                      data-test-subj={'rule_enabled_toggle'}
                     />
                   </EuiCompressedFormRow>
-                )}
 
-                <EuiSpacer />
+                  <EuiSpacer size={'xxl'} />
 
-                <EuiCompressedFormRow
-                  label={
-                    <EuiText size={'s'}>
-                      <strong>Rule level (severity)</strong>
+                  <EuiTitle>
+                    <EuiText size="s">
+                      <h2>Detection</h2>
                     </EuiText>
-                  }
-                  isInvalid={(validateOnMount || props.touched.level) && !!props.errors?.level}
-                  error={props.errors.level}
-                >
-                  <EuiCompressedComboBox
-                    isInvalid={(validateOnMount || props.touched.level) && !!props.errors?.level}
-                    placeholder="Select a rule level"
-                    data-test-subj={'rule_severity_dropdown'}
-                    options={ruleSeverity.map(({ name, value }) => ({ label: name, value }))}
-                    singleSelection={{ asPlainText: true }}
-                    onChange={(e) => props.handleChange('level')(e[0]?.value ?? '')}
-                    onBlur={props.handleBlur('level')}
-                    selectedOptions={
-                      props.values.level
-                        ? [
-                            {
-                              value: props.values.level,
-                              label: getSeverityLabel(props.values.level),
-                            },
-                          ]
-                        : []
-                    }
-                  />
-                </EuiCompressedFormRow>
-
-                <EuiSpacer />
-
-                <EuiCompressedFormRow
-                  label={
-                    <EuiText size={'s'}>
-                      <strong>Rule Status</strong>
-                    </EuiText>
-                  }
-                  isInvalid={(validateOnMount || props.touched.status) && !!props.errors?.status}
-                  error={props.errors.status}
-                >
-                  <EuiCompressedComboBox
-                    isInvalid={(validateOnMount || props.touched.status) && !!props.errors?.status}
-                    placeholder="Select a rule status"
-                    data-test-subj={'rule_status_dropdown'}
-                    options={ruleStatus.map((type: string) => ({ value: type, label: type }))}
-                    singleSelection={{ asPlainText: true }}
-                    onChange={(e) => props.handleChange('status')(e[0]?.value ?? '')}
-                    onBlur={props.handleBlur('status')}
-                    selectedOptions={
-                      props.values.status
-                        ? [{ value: props.values.status, label: String(props.values.status) }]
-                        : []
-                    }
-                  />
-                </EuiCompressedFormRow>
-
-                <EuiSpacer />
-
-                <EuiCompressedFormRow
-                  label={
-                    <EuiText size={'s'}>
-                      <strong>Enabled</strong>
-                    </EuiText>
-                  }
-                >
-                  <EuiSwitch
-                    label={props.values.enabled ? 'Rule is enabled' : 'Rule is disabled'}
-                    checked={props.values.enabled}
-                    onChange={(e) => props.setFieldValue('enabled', e.target.checked)}
-                    data-test-subj={'rule_enabled_toggle'}
-                  />
-                </EuiCompressedFormRow>
-
-                <EuiSpacer size={'xxl'} />
-
-                <EuiTitle>
+                  </EuiTitle>
                   <EuiText size="s">
-                    <h2>Detection</h2>
+                    <p>Define the detection criteria for the rule</p>
                   </EuiText>
-                </EuiTitle>
-                <EuiText size="s">
-                  <p>Define the detection criteria for the rule</p>
-                </EuiText>
 
-                <EuiSpacer />
+                  <EuiSpacer />
 
-                <DetectionVisualEditor
-                  isInvalid={(validateOnMount || props.touched.detection) && isDetectionInvalid}
-                  detectionYml={props.values.detection}
-                  goToYamlEditor={setSelectedEditorType}
-                  setIsDetectionInvalid={(isInvalid: boolean) => {
-                    if (isInvalid) {
-                      props.errors.detection = 'Invalid detection entries';
-                    } else {
-                      delete props.errors.detection;
-                    }
+                  <DetectionVisualEditor
+                    isInvalid={(validateOnMount || props.touched.detection) && isDetectionInvalid}
+                    detectionYml={props.values.detection}
+                    goToYamlEditor={setSelectedEditorType}
+                    setIsDetectionInvalid={(isInvalid: boolean) => {
+                      if (isInvalid) {
+                        props.errors.detection = 'Invalid detection entries';
+                      } else {
+                        delete props.errors.detection;
+                      }
 
-                    setIsDetectionInvalid(isInvalid);
-                  }}
-                  onChange={(detection: string) => {
-                    props.handleChange('detection')(detection);
-                  }}
-                />
-
-                <EuiSpacer size="xl" />
-
-                <EuiAccordion
-                  id="mitre-attack"
-                  initialIsOpen={MITRE_SECTIONS.some(
-                    (s) => props.values.mitre[s.field]?.length > 0
-                  )}
-                  buttonContent={
-                    <>
-                      MITRE ATT&CK <i>- optional</i>
-                      <EuiText size="xs" color={props.errors.mitre ? 'danger' : 'subdued'}>
-                        {props.errors.mitre
-                          ? 'Some entries are incomplete. Both ID and name are required.'
-                          : 'Map this rule to MITRE ATT&CK tactics, techniques and subtechniques.'}
-                      </EuiText>
-                    </>
-                  }
-                  paddingSize="l"
-                >
-                  <EuiSpacer size="s" />
-                  <MitreVisualEditor
-                    mitre={props.values.mitre}
-                    onChange={(state) => props.setFieldValue('mitre', state)}
+                      setIsDetectionInvalid(isInvalid);
+                    }}
+                    onChange={(detection: string) => {
+                      props.handleChange('detection')(detection);
+                    }}
                   />
-                </EuiAccordion>
 
-                <EuiSpacer size="xl" />
+                  <EuiSpacer size="xl" />
 
-                <EuiAccordion
-                  id="compliance"
-                  initialIsOpen={!!props.values.compliance}
-                  buttonContent={
-                    <>
-                      Compliance <i>- optional</i>
-                      <EuiText size="xs" color="subdued">
-                        Map this rule to compliance frameworks (PCI DSS, GDPR, HIPAA, etc.).
-                      </EuiText>
-                    </>
-                  }
-                  paddingSize="l"
-                >
-                  <EuiSpacer size="s" />
-                  <ComplianceVisualEditor
-                    complianceYml={props.values.compliance || ''}
-                    onChange={(value) => props.setFieldValue('compliance', value)}
-                  />
-                </EuiAccordion>
-
-                <EuiSpacer size={'xl'} />
-
-                <div style={{ maxWidth: 1000 }}>
                   <EuiAccordion
-                    id={'additional-details'}
-                    initialIsOpen={hasAdditionalDetails}
+                    id="mitre-attack"
+                    initialIsOpen={MITRE_SECTIONS.some(
+                      (s) => props.values.mitre[s.field]?.length > 0
+                    )}
                     buttonContent={
                       <>
-                        Additional details <i>- optional</i>
+                        MITRE ATT&CK <i>- optional</i>
+                        <EuiText size="xs" color={props.errors.mitre ? 'danger' : 'subdued'}>
+                          {props.errors.mitre
+                            ? 'Some entries are incomplete. Both ID and name are required.'
+                            : 'Map this rule to MITRE ATT&CK tactics, techniques and subtechniques.'}
+                        </EuiText>
                       </>
                     }
                     paddingSize="l"
                   >
-                    <div className={'rule-editor-form-additional-details-panel-body'}>
-                      <FieldTextArray
-                        name="tags"
-                        placeholder={'tag'}
-                        label={
-                          <>
-                            <EuiText size={'m'}>
-                              <strong>Tags </strong>
-                              <i>- optional</i>
-                            </EuiText>
-
-                            <EuiSpacer size={'m'} />
-
-                            <EuiText size={'xs'}>
-                              <strong>Tag</strong>
-                            </EuiText>
-                          </>
-                        }
-                        addButtonName="Add tag"
-                        fields={props.values.tags}
-                        error={props.errors.tags}
-                        isInvalid={(validateOnMount || props.touched.tags) && !!props.errors.tags}
-                        onChange={(tags) => {
-                          props.touched.tags = true;
-                          props.setFieldValue('tags', tags);
-                        }}
-                        data-test-subj={'rule_tags_field'}
-                      />
-
-                      <FieldTextArray
-                        name="references"
-                        placeholder={'http://'}
-                        label={
-                          <>
-                            <EuiText size={'m'}>
-                              <strong>References </strong>
-                              <i>- optional</i>
-                            </EuiText>
-
-                            <EuiSpacer size={'m'} />
-
-                            <EuiText size={'xs'}>
-                              <strong>URL</strong>
-                            </EuiText>
-                          </>
-                        }
-                        addButtonName="Add URL"
-                        fields={props.values.metadata.references}
-                        error={props.errors?.metadata?.references}
-                        isInvalid={
-                          (validateOnMount || props.touched.metadata?.references) &&
-                          !!props.errors?.metadata?.references
-                        }
-                        onChange={(references) => {
-                          props.setFieldTouched('metadata.references', true, false);
-                          props.setFieldValue('metadata.references', references);
-                        }}
-                        data-test-subj={'rule_references_field'}
-                      />
-
-                      <FieldTextArray
-                        name="supports"
-                        placeholder={'Support (e.g. 2.1.0)'}
-                        label={
-                          <>
-                            <EuiText size={'m'}>
-                              <strong>Supports </strong>
-                              <i>- optional</i>
-                            </EuiText>
-
-                            <EuiSpacer size={'m'} />
-
-                            <EuiText size={'xs'}>
-                              <strong>Support</strong>
-                            </EuiText>
-                          </>
-                        }
-                        addButtonName="Add support"
-                        fields={props.values.metadata.supports}
-                        error={props.errors?.metadata?.supports}
-                        isInvalid={
-                          (validateOnMount || props.touched.metadata?.supports) &&
-                          !!props.errors?.metadata?.supports
-                        }
-                        onChange={(supports) => {
-                          props.setFieldTouched('metadata.supports', true, false);
-                          props.setFieldValue('metadata.supports', supports);
-                        }}
-                        data-test-subj={'rule_supports_field'}
-                      />
-
-                      <EuiCompressedFormRow
-                        label={
-                          <EuiText size={'s'}>
-                            <strong>Documentation </strong>
-                            <i>- optional</i>
-                          </EuiText>
-                        }
-                      >
-                        <EuiCompressedTextArea
-                          placeholder="Enter documentation"
-                          data-test-subj={'rule_documentation_field'}
-                          value={props.values.metadata.documentation}
-                          onChange={(e) => {
-                            props.setFieldValue('metadata.documentation', e.target.value);
-                            props.setFieldTouched('metadata.documentation', true, false);
-                          }}
-                          onBlur={props.handleBlur('metadata.documentation')}
-                        />
-                      </EuiCompressedFormRow>
-
-                      <FieldTextArray
-                        name="false_positives"
-                        placeholder={'False positive when...'}
-                        label={
-                          <>
-                            <EuiText size={'m'}>
-                              <strong>False positive cases </strong>
-                              <i>- optional</i>
-                            </EuiText>
-                          </>
-                        }
-                        addButtonName="Add false positive"
-                        fields={props.values.falsePositives}
-                        error={props.errors.falsePositives}
-                        isInvalid={
-                          (validateOnMount || props.touched.falsePositives) &&
-                          !!props.errors?.falsePositives
-                        }
-                        onChange={(falsePositives) => {
-                          props.touched.falsePositives = true;
-                          props.setFieldValue('falsePositives', falsePositives);
-                        }}
-                        data-test-subj={'rule_falsePositives_field'}
-                      />
-                    </div>
+                    <EuiSpacer size="s" />
+                    <MitreVisualEditor
+                      mitre={props.values.mitre}
+                      onChange={(state) => props.setFieldValue('mitre', state)}
+                    />
                   </EuiAccordion>
-                  <EuiSpacer size={'m'} />
-                </div>
-              </>
-            )}
-          </EuiPanel>
 
-          <EuiBottomBar>
-            <EuiFlexGroup
-              gutterSize="s"
-              justifyContent="flexEnd"
-              alignItems="center"
-              responsive={false}
-            >
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  color="ghost"
-                  size="s"
-                  iconType="cross"
-                  onClick={cancel}
-                  isDisabled={props.isSubmitting}
-                >
-                  Cancel
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiToolTip
-                  content={
-                    <>
-                      <p>
-                        {mode === 'create' && !integrationId
-                          ? 'Select an integration to enable creating the rule'
-                          : ''}
-                      </p>
-                      <p>
-                        {Object.keys(props.errors).length > 0
-                          ? 'Please fix the errors in the form to proceed'
-                          : ''}
-                      </p>
-                    </>
-                  }
-                  position="top"
-                >
-                  <EuiButton
-                    color="primary"
-                    fill
-                    iconType="check"
-                    size="s"
-                    isLoading={props.isSubmitting}
-                    disabled={
-                      (mode === 'create' && !integrationId) || Object.keys(props.errors).length > 0
+                  <EuiSpacer size="xl" />
+
+                  <EuiAccordion
+                    id="compliance"
+                    initialIsOpen={!!props.values.compliance}
+                    buttonContent={
+                      <>
+                        Compliance <i>- optional</i>
+                        <EuiText size="xs" color="subdued">
+                          Map this rule to compliance frameworks (PCI DSS, GDPR, HIPAA, etc.).
+                        </EuiText>
+                      </>
                     }
-                    onClick={() => props.handleSubmit()}
-                    data-test-subj={'submit_rule_form_button'}
+                    paddingSize="l"
                   >
-                    {mode === 'create' ? 'Create rule' : 'Edit rule'}
-                  </EuiButton>
-                </EuiToolTip>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiBottomBar>
-        </Form>
+                    <EuiSpacer size="s" />
+                    <ComplianceVisualEditor
+                      complianceYml={props.values.compliance || ''}
+                      onChange={(value) => props.setFieldValue('compliance', value)}
+                    />
+                  </EuiAccordion>
+
+                  <EuiSpacer size={'xl'} />
+
+                  <div style={{ maxWidth: 1000 }}>
+                    <EuiAccordion
+                      id={'additional-details'}
+                      initialIsOpen={hasAdditionalDetails}
+                      buttonContent={
+                        <>
+                          Additional details <i>- optional</i>
+                        </>
+                      }
+                      paddingSize="l"
+                    >
+                      <div className={'rule-editor-form-additional-details-panel-body'}>
+                        <FieldTextArray
+                          name="tags"
+                          placeholder={'tag'}
+                          label={
+                            <>
+                              <EuiText size={'m'}>
+                                <strong>Tags </strong>
+                                <i>- optional</i>
+                              </EuiText>
+
+                              <EuiSpacer size={'m'} />
+
+                              <EuiText size={'xs'}>
+                                <strong>Tag</strong>
+                              </EuiText>
+                            </>
+                          }
+                          addButtonName="Add tag"
+                          fields={props.values.tags}
+                          error={props.errors.tags}
+                          isInvalid={(validateOnMount || props.touched.tags) && !!props.errors.tags}
+                          onChange={(tags) => {
+                            props.touched.tags = true;
+                            props.setFieldValue('tags', tags);
+                          }}
+                          data-test-subj={'rule_tags_field'}
+                        />
+
+                        <FieldTextArray
+                          name="references"
+                          placeholder={'http://'}
+                          label={
+                            <>
+                              <EuiText size={'m'}>
+                                <strong>References </strong>
+                                <i>- optional</i>
+                              </EuiText>
+
+                              <EuiSpacer size={'m'} />
+
+                              <EuiText size={'xs'}>
+                                <strong>URL</strong>
+                              </EuiText>
+                            </>
+                          }
+                          addButtonName="Add URL"
+                          fields={props.values.metadata.references}
+                          error={props.errors?.metadata?.references}
+                          isInvalid={
+                            (validateOnMount || props.touched.metadata?.references) &&
+                            !!props.errors?.metadata?.references
+                          }
+                          onChange={(references) => {
+                            props.setFieldTouched('metadata.references', true, false);
+                            props.setFieldValue('metadata.references', references);
+                          }}
+                          data-test-subj={'rule_references_field'}
+                        />
+
+                        <FieldTextArray
+                          name="supports"
+                          placeholder={'Support (e.g. 2.1.0)'}
+                          label={
+                            <>
+                              <EuiText size={'m'}>
+                                <strong>Supports </strong>
+                                <i>- optional</i>
+                              </EuiText>
+
+                              <EuiSpacer size={'m'} />
+
+                              <EuiText size={'xs'}>
+                                <strong>Support</strong>
+                              </EuiText>
+                            </>
+                          }
+                          addButtonName="Add support"
+                          fields={props.values.metadata.supports}
+                          error={props.errors?.metadata?.supports}
+                          isInvalid={
+                            (validateOnMount || props.touched.metadata?.supports) &&
+                            !!props.errors?.metadata?.supports
+                          }
+                          onChange={(supports) => {
+                            props.setFieldTouched('metadata.supports', true, false);
+                            props.setFieldValue('metadata.supports', supports);
+                          }}
+                          data-test-subj={'rule_supports_field'}
+                        />
+
+                        <EuiCompressedFormRow
+                          label={
+                            <EuiText size={'s'}>
+                              <strong>Documentation </strong>
+                              <i>- optional</i>
+                            </EuiText>
+                          }
+                        >
+                          <EuiCompressedTextArea
+                            placeholder="Enter documentation"
+                            data-test-subj={'rule_documentation_field'}
+                            value={props.values.metadata.documentation}
+                            onChange={(e) => {
+                              props.setFieldValue('metadata.documentation', e.target.value);
+                              props.setFieldTouched('metadata.documentation', true, false);
+                            }}
+                            onBlur={props.handleBlur('metadata.documentation')}
+                          />
+                        </EuiCompressedFormRow>
+
+                        <FieldTextArray
+                          name="false_positives"
+                          placeholder={'False positive when...'}
+                          label={
+                            <>
+                              <EuiText size={'m'}>
+                                <strong>False positive cases </strong>
+                                <i>- optional</i>
+                              </EuiText>
+                            </>
+                          }
+                          addButtonName="Add false positive"
+                          fields={props.values.falsePositives}
+                          error={props.errors.falsePositives}
+                          isInvalid={
+                            (validateOnMount || props.touched.falsePositives) &&
+                            !!props.errors?.falsePositives
+                          }
+                          onChange={(falsePositives) => {
+                            props.touched.falsePositives = true;
+                            props.setFieldValue('falsePositives', falsePositives);
+                          }}
+                          data-test-subj={'rule_falsePositives_field'}
+                        />
+                      </div>
+                    </EuiAccordion>
+                    <EuiSpacer size={'m'} />
+                  </div>
+                </>
+              )}
+            </EuiPanel>
+
+            <EuiBottomBar>
+              <EuiFlexGroup
+                gutterSize="s"
+                justifyContent="flexEnd"
+                alignItems="center"
+                responsive={false}
+              >
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    color="ghost"
+                    size="s"
+                    iconType="cross"
+                    onClick={cancel}
+                    isDisabled={props.isSubmitting}
+                  >
+                    Cancel
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiToolTip
+                    content={
+                      <>
+                        <p>
+                          {mode === 'create' && !integrationId
+                            ? 'Select an integration to enable creating the rule'
+                            : ''}
+                        </p>
+                        <p>
+                          {Object.keys(props.errors).length > 0
+                            ? 'Please fix the errors in the form to proceed'
+                            : ''}
+                        </p>
+                      </>
+                    }
+                    position="top"
+                  >
+                    <EuiButton
+                      color="primary"
+                      fill
+                      iconType="check"
+                      size="s"
+                      isLoading={props.isSubmitting}
+                      disabled={
+                        (mode === 'create' && !integrationId) ||
+                        Object.keys(props.errors).length > 0
+                      }
+                      onClick={() => props.handleSubmit()}
+                      data-test-subj={'submit_rule_form_button'}
+                    >
+                      {mode === 'create' ? 'Create rule' : 'Edit rule'}
+                    </EuiButton>
+                  </EuiToolTip>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiBottomBar>
+          </Form>
         );
       }}
     </Formik>

--- a/public/pages/WazuhRules/components/RuleEditor/RuleEditorForm.tsx
+++ b/public/pages/WazuhRules/components/RuleEditor/RuleEditorForm.tsx
@@ -10,6 +10,7 @@ import {
   EuiBottomBar,
   EuiButton,
   EuiButtonEmpty,
+  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -43,7 +44,7 @@ import { YamlRuleEditorComponent } from './components/YamlRuleEditorComponent/Ya
 import { mapFormToRule, mapRuleToForm } from './mappers';
 import { DetectionVisualEditor } from '../../../Rules/components/RuleEditor/DetectionVisualEditor';
 import { MitreVisualEditor } from './components/MitreVisualEditor/MitreVisualEditor';
-import { MITRE_SECTIONS } from '../../utils/mitre';
+import { parseMitreYmlWithErrors } from '../../utils/mitre';
 import { ComplianceVisualEditor } from './components/ComplianceVisualEditor/ComplianceVisualEditor';
 import { getSeverityLabel } from '../../../Correlations/utils/constants';
 import { PageHeader } from '../../../../components/PageHeader/PageHeader';
@@ -169,14 +170,9 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
           errors.tags = `Tags must start with '${TAGS_PREFIX}'`;
         }
 
-        const mitreErrors: Partial<Record<keyof typeof values.mitre, string>> = {};
-        for (const section of MITRE_SECTIONS) {
-          if (values.mitre[section.field].some((e) => !e.id || !e.name)) {
-            mitreErrors[section.field] = 'Both ID and name are required for each entry.';
-          }
-        }
-        if (Object.keys(mitreErrors).length > 0) {
-          errors.mitre = mitreErrors as FormikErrors<RuleEditorFormModel>['mitre'];
+        const mitreErrors = parseMitreYmlWithErrors(values.mitre).errors;
+        if (mitreErrors.length) {
+          errors.mitre = mitreErrors.join(' ');
         }
 
         return errors;
@@ -193,6 +189,9 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
       }}
     >
       {(props) => {
+        // Derived, not stored: the raw YAML in `values.mitre` is the single source of truth.
+        const mitreErrors = parseMitreYmlWithErrors(props.values.mitre).errors;
+
         const onIntegrationCreateSuccess = (newOption: {
           id: string;
           value: string;
@@ -543,15 +542,15 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
 
                   <EuiAccordion
                     id="mitre-attack"
-                    initialIsOpen={MITRE_SECTIONS.some(
-                      (s) => props.values.mitre[s.field]?.length > 0
-                    )}
+                    initialIsOpen={!!props.values.mitre}
                     buttonContent={
                       <>
                         MITRE ATT&CK <i>- optional</i>
                         <EuiText size="xs" color={props.errors.mitre ? 'danger' : 'subdued'}>
-                          {props.errors.mitre
-                            ? 'Some entries are incomplete. Both ID and name are required.'
+                          {mitreErrors.length
+                            ? `The MITRE ATT&CK block has ${mitreErrors.length} problem${
+                                mitreErrors.length > 1 ? 's' : ''
+                              }. Expand to see the details.`
                             : 'Map this rule to MITRE ATT&CK tactics, techniques and subtechniques.'}
                         </EuiText>
                       </>
@@ -559,9 +558,26 @@ export const RuleEditorForm: React.FC<VisualRuleEditorProps> = ({
                     paddingSize="l"
                   >
                     <EuiSpacer size="s" />
+                    {!!mitreErrors.length && (
+                      <>
+                        <EuiCallOut
+                          size="s"
+                          color="danger"
+                          title="Fix the MITRE ATT&CK block in the YAML editor, or replace it using the fields below."
+                          data-test-subj="mitre_structural_errors"
+                        >
+                          <ul>
+                            {mitreErrors.map((error, i) => (
+                              <li key={i}>{error}</li>
+                            ))}
+                          </ul>
+                        </EuiCallOut>
+                        <EuiSpacer size="s" />
+                      </>
+                    )}
                     <MitreVisualEditor
-                      mitre={props.values.mitre}
-                      onChange={(state) => props.setFieldValue('mitre', state)}
+                      mitreYml={props.values.mitre}
+                      onChange={(yml) => props.setFieldValue('mitre', yml)}
                     />
                   </EuiAccordion>
 

--- a/public/pages/WazuhRules/components/RuleEditor/RuleEditorFormModel.ts
+++ b/public/pages/WazuhRules/components/RuleEditor/RuleEditorFormModel.ts
@@ -4,7 +4,6 @@
  */
 
 import { ruleStatus } from '../../../Rules/utils/constants';
-import { MitreState, EMPTY_MITRE } from '../../utils/mitre';
 
 export interface RuleEditorFormModel {
   id: string;
@@ -15,7 +14,7 @@ export interface RuleEditorFormModel {
   detection: string;
   level: string;
   falsePositives: string[];
-  mitre: MitreState;
+  mitre: string;
   compliance: string;
   enabled: boolean;
   metadata: {
@@ -37,7 +36,7 @@ export const ruleEditorStateDefaultValue: RuleEditorFormModel = {
   detection: '',
   level: '',
   falsePositives: [],
-  mitre: EMPTY_MITRE,
+  mitre: '',
   compliance: '',
   enabled: true,
   metadata: {

--- a/public/pages/WazuhRules/components/RuleEditor/components/MitreVisualEditor/MitreVisualEditor.tsx
+++ b/public/pages/WazuhRules/components/RuleEditor/components/MitreVisualEditor/MitreVisualEditor.tsx
@@ -14,21 +14,27 @@ import {
   EuiText,
   EuiToolTip,
 } from '@elastic/eui';
-import { MitreEntry, MitreState, MITRE_SECTIONS } from '../../../../utils/mitre';
+import {
+  MitreEntry,
+  MitreState,
+  MITRE_SECTIONS,
+  parseMitreYml,
+  dumpMitreYml,
+} from '../../../../utils/mitre';
 
 export interface MitreVisualEditorProps {
-  mitre: MitreState;
-  onChange: (state: MitreState) => void;
+  mitreYml: string;
+  onChange: (yml: string) => void;
 }
 
-export const MitreVisualEditor: React.FC<MitreVisualEditorProps> = ({ mitre, onChange }) => {
-  const [state, setState] = useState<MitreState>(mitre);
+export const MitreVisualEditor: React.FC<MitreVisualEditorProps> = ({ mitreYml, onChange }) => {
+  const [state, setState] = useState<MitreState>(() => parseMitreYml(mitreYml));
 
   const isEntryInvalid = (entry: MitreEntry) => !!entry.id !== !!entry.name;
 
   const update = (newState: MitreState) => {
     setState(newState);
-    onChange(newState);
+    onChange(dumpMitreYml(newState));
   };
 
   const handleChange = (

--- a/public/pages/WazuhRules/components/RuleEditor/mappers.ts
+++ b/public/pages/WazuhRules/components/RuleEditor/mappers.ts
@@ -6,7 +6,6 @@
 import { Rule } from '../../../../../types';
 import { getLogTypeFromLogSource } from '../../utils/helpers';
 import { RuleEditorFormModel, ruleEditorStateDefaultValue } from './RuleEditorFormModel';
-import { parseMitreYml, dumpMitreYml } from '../../utils/mitre';
 
 export const mapFormToRule = (formState: RuleEditorFormModel): Rule => {
   const logSource = { ...(formState.log_source ?? {}) };
@@ -40,7 +39,7 @@ export const mapFormToRule = (formState: RuleEditorFormModel): Rule => {
       documentation,
       supports,
     },
-    mitre: dumpMitreYml(formState.mitre),
+    mitre: formState.mitre,
     compliance: formState.compliance,
     enabled: formState.enabled,
   };
@@ -69,7 +68,7 @@ export const mapRuleToForm = (rule: Rule): RuleEditorFormModel => {
     falsePositives: rule.false_positives?.length
       ? rule.false_positives.map((fp) => fp.value)
       : ruleEditorStateDefaultValue.falsePositives,
-    mitre: parseMitreYml(rule.mitre || ''),
+    mitre: rule.mitre || '',
     compliance: rule.compliance,
     enabled: rule.enabled ?? true,
     metadata: {

--- a/public/pages/WazuhRules/utils/mitre.ts
+++ b/public/pages/WazuhRules/utils/mitre.ts
@@ -48,28 +48,155 @@ export const MITRE_SECTIONS: MitreSection[] = [
   },
 ];
 
-export const EMPTY_MITRE: MitreState = { tactic: [], technique: [], subtechnique: [] };
+export const MITRE_CATEGORIES = MITRE_SECTIONS.map((section) => section.field);
 
-function parseMitreField(field: unknown): MitreEntry[] {
-  if (typeof field !== 'object' || field === null || Array.isArray(field)) return [];
-  const obj = field as Record<string, unknown>;
-  const ids = Array.isArray(obj.id) ? obj.id : [];
-  const names = Array.isArray(obj.name) ? obj.name : [];
-  const len = Math.max(ids.length, names.length);
-  return Array.from({ length: len }, (_, i) => ({ id: ids[i] ?? '', name: names[i] ?? '' }));
+export interface MitreParseResult {
+  state: MitreState;
+  errors: string[];
+}
+
+function emptyMitreState(): MitreState {
+  return { tactic: [], technique: [], subtechnique: [] };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isScalar(value: unknown): boolean {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+// A single value is valid shorthand for a one-entry list: the indexer accepts it and
+// prepackaged content relies on it (the SCA rules use '{{check.mitre.tactic.id}}').
+function toList(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+function parseMitreColumn(
+  category: string,
+  key: 'id' | 'name',
+  raw: unknown,
+  errors: string[]
+): string[] {
+  return toList(raw).map((item, index) => {
+    if (!isScalar(item)) {
+      errors.push(`'mitre.${category}.${key}[${index}]' must be a single value.`);
+      return '';
+    }
+    const text = String(item).trim();
+    if (!text) {
+      errors.push(`'mitre.${category}.${key}[${index}]' cannot be empty.`);
+    }
+    return text;
+  });
+}
+
+interface CategoryParseResult {
+  entries: MitreEntry[];
+  errors: string[];
+}
+
+function parseMitreCategory(category: string, value: unknown): CategoryParseResult {
+  if (!isPlainObject(value)) {
+    return {
+      entries: [],
+      errors: [`'mitre.${category}' must be an object with 'id' and 'name' lists.`],
+    };
+  }
+
+  const errors: string[] = [];
+
+  const unsupported = Object.keys(value).filter((key) => key !== 'id' && key !== 'name');
+  if (unsupported.length) {
+    errors.push(
+      `'mitre.${category}' contains unsupported key(s) [${unsupported.join(
+        ', '
+      )}]; expected 'id' and/or 'name'.`
+    );
+  }
+
+  const hasId = value.id !== undefined;
+  const hasName = value.name !== undefined;
+  if (!hasId && !hasName) {
+    errors.push(`'mitre.${category}' must define both 'id' and 'name'.`);
+    return { entries: [], errors };
+  }
+  if (!hasId) {
+    errors.push(`'mitre.${category}.id' is required when 'name' is present.`);
+  }
+  if (!hasName) {
+    errors.push(`'mitre.${category}.name' is required when 'id' is present.`);
+  }
+
+  const ids = hasId ? parseMitreColumn(category, 'id', value.id, errors) : [];
+  const names = hasName ? parseMitreColumn(category, 'name', value.name, errors) : [];
+
+  if (hasId && hasName && ids.length !== names.length) {
+    errors.push(
+      `'mitre.${category}.id' and 'mitre.${category}.name' must have the same number of ` +
+        `entries (got ${ids.length} and ${names.length}).`
+    );
+  }
+
+  const length = Math.max(ids.length, names.length);
+  const entries = Array.from({ length }, (_, i) => ({ id: ids[i] ?? '', name: names[i] ?? '' }));
+
+  return { entries, errors };
+}
+
+/**
+ * Parse the `mitre` YAML block, reporting every structural problem instead of
+ * silently discarding what does not fit the expected shape.
+ */
+export function parseMitreYmlWithErrors(yml: string): MitreParseResult {
+  let parsed: unknown;
+  try {
+    parsed = yml ? load(yml) : null;
+  } catch (error: any) {
+    return {
+      state: emptyMitreState(),
+      errors: [`'mitre' is not valid YAML: ${error?.message ?? 'parse error'}`],
+    };
+  }
+
+  if (parsed === null || parsed === undefined || parsed === '') {
+    return { state: emptyMitreState(), errors: [] };
+  }
+
+  if (!isPlainObject(parsed)) {
+    return {
+      state: emptyMitreState(),
+      errors: [`'mitre' must be an object containing 'tactic', 'technique' and/or 'subtechnique'.`],
+    };
+  }
+
+  const errors: string[] = [];
+
+  const unsupported = Object.keys(parsed).filter(
+    (key) => !MITRE_CATEGORIES.includes(key as keyof MitreState)
+  );
+  if (unsupported.length) {
+    errors.push(
+      `'mitre' contains unsupported ${
+        unsupported.length > 1 ? 'categories' : 'category'
+      } [${unsupported.join(', ')}]; expected one of [${MITRE_CATEGORIES.join(', ')}].`
+    );
+  }
+
+  const state = emptyMitreState();
+  for (const category of MITRE_CATEGORIES) {
+    if (parsed[category] === undefined) continue;
+    const result = parseMitreCategory(category, parsed[category]);
+    state[category] = result.entries;
+    errors.push(...result.errors);
+  }
+
+  return { state, errors };
 }
 
 export function parseMitreYml(yml: string): MitreState {
-  try {
-    const parsed = (yml ? load(yml) : null) as Record<string, unknown> | null | undefined;
-    return {
-      tactic: parseMitreField(parsed?.tactic),
-      technique: parseMitreField(parsed?.technique),
-      subtechnique: parseMitreField(parsed?.subtechnique),
-    };
-  } catch {
-    return { ...EMPTY_MITRE };
-  }
+  return parseMitreYmlWithErrors(yml).state;
 }
 
 export function dumpMitreYml(state: MitreState): string {


### PR DESCRIPTION
## Description

The MITRE ATT&CK block of a rule was silently discarded when it did not match the
expected structure. Writing `mitre: {tactic: [TA0001]}` in the YAML editor removed the
whole block from the editor, with no message explaining why, and the rule could still be
saved.

The cause was in the editor, not the backend: the form kept `mitre` as a normalized
structure with `id` and `name` lists, so any other shape had nowhere to go. The YAML
editor writes through that form state, so the text was regenerated from the sanitized
value and the original input was lost.

Closes #446

## Proposed Changes

- `mitre` is now stored in the form as raw YAML, the same as `compliance` and `detection`.
  The text is passed through unchanged, so nothing is rewritten or lost.
- The block is validated on every change. It reports a category that is not an object,
  unknown categories or keys, a missing `id` or `name`, empty values, mismatched `id`/`name`
  lengths, values that are not single values, and invalid YAML.
- Problems are listed in the editor and prevent saving until they are fixed.
- A single value is still accepted as a one-item list, because the packaged SCA rules use
  it (`tactic: {id: "{{check.mitre.tactic.id}}"}`).

### Results and Evidence


https://github.com/user-attachments/assets/8a549b4d-cc32-486d-a116-8034c4e3706c



### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None in this pull request. Unit tests for the parser and the form mappers will be added
separately.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
