### PR TITLE
Security Analytics UX improvements (#447 group C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 | [#164](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/164) [#347](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/347) | Rules table and details now display the real integration title. |
 | [#178](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/178) | Updated nav menu group label to "Security analytics" to match Wazuh Dashboard capitalization style. |
 | [#353](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/353) | Removed getLogTypeLabel usage across Security analytics |
-| [#447](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/447) | Improved the security analytics UX: unified the user-facing terminology and documented it in `TERMINOLOGY.md`, said what each entity and space is for, added a "How security analytics works" flyout, told the user what to do next on empty lists, replaced the log test status code with a plain-language verdict, and gave the remaining dead ends a cause |
+| [#447](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/447) | Improved the security analytics UX: unified the user-facing terminology and documented it in `TERMINOLOGY.md`, said what each entity and space is for, added a "How security analytics works" flyout, told the user what to do next on empty lists, replaced the log test status code with a plain-language verdict, gave the remaining dead ends a cause, paired asset identifiers with their name so the root decoder reads as a name instead of `decoder/core-wazuh-message/0`, labelled each compliance framework's values with its own unit, and made the space policy panel legible: consistent booleans, enrichments as badges, and a hint on every setting saying what it affects |
 
 ### Removed
 
@@ -44,6 +44,7 @@
 
 | Issue | Comment |
 | ----- | ------- |
+| [#430](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/430) | Fixed the integration detail view reporting "Integration not found" for a promoted integration, because the list linked it by its OpenSearch document id while the view looks it up by the id shared across space copies |
 | [#9](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/9) [#446](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/446) | Fixed YAML Editor when creating or editing detection rules |
 | [#44](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/44) | Fixed detection rule editor causing blank screen |
 | [#315](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/315) | Fixed rule JSON viewer showing the detection field as a YAML string instead of a structured object |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@
 
 | Issue | Comment |
 | ----- | ------- |
-| [#430](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/430) | Fixed the integration detail view reporting "Integration not found" for a promoted integration, because the list linked it by its OpenSearch document id while the view looks it up by the id shared across space copies |
 | [#9](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/9) [#446](https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/446) | Fixed YAML Editor when creating or editing detection rules |
 | [#44](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/44) | Fixed detection rule editor causing blank screen |
 | [#315](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/315) | Fixed rule JSON viewer showing the detection field as a YAML string instead of a structured object |

--- a/public/components/AssetIdentity/AssetIdentity.test.tsx
+++ b/public/components/AssetIdentity/AssetIdentity.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Wazuh Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AssetIdentity, formatAssetLabel } from './AssetIdentity';
+
+const IDENTIFIER = 'decoder/core-wazuh-message/0';
+const TITLE = 'Wazuh message decoder';
+
+describe('formatAssetLabel', () => {
+  it('pairs the name with the identifier', () => {
+    expect(formatAssetLabel(TITLE, IDENTIFIER)).toBe(
+      'Wazuh message decoder (decoder/core-wazuh-message/0)'
+    );
+  });
+
+  it('falls back to the identifier alone when the asset has no title', () => {
+    expect(formatAssetLabel(undefined, IDENTIFIER)).toBe(IDENTIFIER);
+  });
+
+  it('returns an empty string with nothing to show, so a caller can fall back', () => {
+    expect(formatAssetLabel(undefined, undefined)).toBe('');
+  });
+});
+
+describe('AssetIdentity', () => {
+  it('shows the name and keeps the identifier underneath', () => {
+    const { getByText } = render(<AssetIdentity title={TITLE} identifier={IDENTIFIER} />);
+
+    expect(getByText(TITLE)).toBeInTheDocument();
+    expect(getByText(IDENTIFIER)).toBeInTheDocument();
+  });
+
+  it('shows the identifier alone when the asset has no title', () => {
+    const { getByText, queryByText } = render(<AssetIdentity identifier={IDENTIFIER} />);
+
+    expect(getByText(IDENTIFIER)).toBeInTheDocument();
+    expect(queryByText(TITLE)).toBeNull();
+  });
+
+  it('renders the empty value when there is no identifier', () => {
+    // A policy with no root decoder reaches this, and a dash is what the panel shows for
+    // every other unset value.
+    const { getByText } = render(<AssetIdentity title={TITLE} />);
+
+    expect(getByText('-')).toBeInTheDocument();
+  });
+
+  it('takes the empty value from the caller', () => {
+    const { getByText } = render(<AssetIdentity emptyValue="Not defined" />);
+
+    expect(getByText('Not defined')).toBeInTheDocument();
+  });
+});

--- a/public/components/AssetIdentity/AssetIdentity.tsx
+++ b/public/components/AssetIdentity/AssetIdentity.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Wazuh Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import React from 'react';
+import { EuiText } from '@elastic/eui';
+
+/**
+ * A catalog asset carries two names. For a decoder, `document.name` holds the machine
+ * identifier (`decoder/core-wazuh-message/0`) and `document.metadata.title` holds the
+ * human name (`Wazuh message decoder`). Screens that printed the identifier alone left
+ * the reader decoding an address. Dropping it is worse: the engine errors, the promote
+ * flow and the policy all refer to an asset by that identifier.
+ *
+ * Show both, name first. Use `formatAssetLabel` where only a string fits, such as a
+ * combo box option, and `AssetIdentity` where two lines fit.
+ */
+
+const truncateStyle: React.CSSProperties = {
+  display: 'block',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
+/** Single-line pairing, for a select or combo box option. */
+export const formatAssetLabel = (title?: string, identifier?: string): string => {
+  if (!identifier) return title ?? '';
+  if (!title) return identifier;
+  return `${title} (${identifier})`;
+};
+
+export interface AssetIdentityProps {
+  title?: string;
+  identifier?: string;
+  /** Rendered when there is no identifier at all. */
+  emptyValue?: React.ReactNode;
+}
+
+/** Two-line pairing: the name, then the identifier underneath. */
+export const AssetIdentity: React.FC<AssetIdentityProps> = ({
+  title,
+  identifier,
+  emptyValue = '-',
+}) => {
+  if (!identifier) {
+    return <>{emptyValue}</>;
+  }
+
+  if (!title) {
+    return (
+      <span title={identifier} style={truncateStyle}>
+        {identifier}
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <span title={title} style={truncateStyle}>
+        {title}
+      </span>
+      <EuiText size="xs" color="subdued">
+        <span title={identifier} style={truncateStyle}>
+          {identifier}
+        </span>
+      </EuiText>
+    </>
+  );
+};

--- a/public/components/AssetIdentity/index.ts
+++ b/public/components/AssetIdentity/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Wazuh Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export { AssetIdentity, formatAssetLabel } from './AssetIdentity';
+export type { AssetIdentityProps } from './AssetIdentity';

--- a/public/components/WazuhPageHeader/WazuhPageHeader.tsx
+++ b/public/components/WazuhPageHeader/WazuhPageHeader.tsx
@@ -33,9 +33,9 @@ const DESCRIPTION_STYLE: React.CSSProperties = { maxWidth: '90ch' };
  * The page header every security analytics list page shares: one row for the title and
  * its controls, one row for the description.
  *
- * Sharing a row made the description inherit whatever width the controls left over, so
- * the longest ones wrapped while the space beside them stayed empty. Every page also
- * repeated the block by hand and had drifted apart on alignment and spacing.
+ * Sharing one row, the description took whatever width the controls left over. The long
+ * ones wrapped while the space beside them stayed empty. Six pages also repeated the
+ * block by hand and had drifted apart on alignment and spacing.
  *
  * This wraps the upstream `PageHeader` rather than changing it: the updated-UX branch
  * still hands the title and description to the platform's own header, and only the
@@ -49,7 +49,7 @@ export const WazuhPageHeader: React.FC<WazuhPageHeaderProps> = ({
 }) => (
   <PageHeader {...pageHeaderProps}>
     <EuiFlexItem>
-      <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="m">
+      <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" gutterSize="m" wrap>
         <EuiFlexItem>
           <EuiText size="s">
             <h1>{title}</h1>

--- a/public/pages/Decoders/containers/DecoderFormPage.tsx
+++ b/public/pages/Decoders/containers/DecoderFormPage.tsx
@@ -101,7 +101,9 @@ export const DecoderFormPage: React.FC<DecoderFormPageProps> = (props) => {
             BREADCRUMBS.NORMALIZATION,
             BREADCRUMBS.DECODERS,
             BREADCRUMBS.DECODERS_EDIT,
-            { text: response?.document.name },
+            // name the decoder in the trail. A breadcrumb has room for one
+            // string, and the identifier is already on screen inside the YAML.
+            { text: response?.document.metadata?.title || response?.document.name },
           ]);
         } catch (error) {
           errorNotificationToast(

--- a/public/pages/Detectors/containers/Detectors/__snapshots__/Detectors.test.tsx.snap
+++ b/public/pages/Detectors/containers/Detectors/__snapshots__/Detectors.test.tsx.snap
@@ -113,9 +113,10 @@ exports[`<Detectors /> spec renders the component 1`] = `
                 alignItems="center"
                 gutterSize="m"
                 justifyContent="spaceBetween"
+                wrap={true}
               >
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
                 >
                   <EuiFlexItem>
                     <div

--- a/public/pages/Integrations/components/EditPolicy.tsx
+++ b/public/pages/Integrations/components/EditPolicy.tsx
@@ -34,6 +34,7 @@ import { INTEGRATION_AUTHOR_REGEX, validateName } from '../../../utils/validatio
 import { buildDecodersSearchQuery } from '../../Decoders/utils/constants';
 import { SPACE_ACTIONS } from '../../../../common/constants';
 import { actionIsAllowedOnSpace, getSpaceTypeLabel } from '../../../../common/helpers';
+import { AssetIdentity, formatAssetLabel } from '../../../components/AssetIdentity';
 import { UI_DISABLED_SETTINGS_IDS, isUiSettingDisabled } from '../../../utils/helpers';
 import { ALLOWED_ENRICHMENTS, ENRICHMENT_LABELS, EnrichmentType } from '../constants/enrichments';
 
@@ -91,7 +92,9 @@ const EditForm: React.FC<{}> = withPolicyGuard({
     if (rootDecoder?.document) {
       return [
         {
-          label: rootDecoder.document.name,
+          // `root_decoder` is saved from `value.document.id`, so the label is free to name
+          // the decoder instead of addressing it.
+          label: formatAssetLabel(rootDecoder.document.metadata?.title, rootDecoder.document.name),
           value: rootDecoder,
         },
       ];
@@ -191,13 +194,16 @@ const EditForm: React.FC<{}> = withPolicyGuard({
           size: DECODER_SEARCH_SIZE,
           sort: [{ ['document.name']: { order: 'asc', unmapped_type: 'keyword' } }],
           query,
-          _source: { includes: ['document.id', 'document.name'] },
+          // The title is what a reader recognises; the name is the identifier.
+          _source: { includes: ['document.id', 'document.name', 'document.metadata.title'] },
         },
         space
       );
       setDecoderList(
         response.items.map((item) => ({
-          label: item?.document?.name ?? item?.document?.id,
+          label:
+            formatAssetLabel(item?.document?.metadata?.title, item?.document?.name) ||
+            (item?.document?.id ?? ''),
           value: item,
         }))
       );
@@ -362,7 +368,7 @@ const EditForm: React.FC<{}> = withPolicyGuard({
             renderBooleanValue(policyDetails.enabled)
           )}
         </EuiCompressedFormRow>
-        <EuiCompressedFormRow label="Root Decoder">
+        <EuiCompressedFormRow label="Root decoder">
           {canEditPolicy ? (
             <EuiComboBox
               placeholder="Search and select a decoder"
@@ -385,7 +391,14 @@ const EditForm: React.FC<{}> = withPolicyGuard({
               async
             />
           ) : (
-            renderTextValue(rootDecoder?.document?.name)
+            // The same field pairs the name with the identifier when it is editable, so the
+            // read-only branch cannot show the identifier alone.
+            <EuiText size="s" color="subdued">
+              <AssetIdentity
+                title={rootDecoder?.document?.metadata?.title}
+                identifier={rootDecoder?.document?.name}
+              />
+            </EuiText>
           )}
         </EuiCompressedFormRow>
         {showAnyIndexingSetting && (

--- a/public/pages/Integrations/components/PolicyInfoCard.tsx
+++ b/public/pages/Integrations/components/PolicyInfoCard.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState } from 'react';
 import {
+  EuiBadge,
   EuiCard,
   EuiDescriptionList,
   EuiDescriptionListDescription,
@@ -14,14 +15,17 @@ import {
   EuiHealth,
   EuiLoadingContent,
   EuiSpacer,
+  EuiIconTip,
   EuiTab,
   EuiTabs,
+  EuiText,
 } from '@elastic/eui';
 import { DecoderSource, PolicyDocument, Space } from '../../../../types';
 import { NotificationsStart } from 'opensearch-dashboards/public';
 import { ENRICHMENT_LABELS, EnrichmentType } from '../constants/enrichments';
 import { formatIntegrationMetadataDate } from '../utils/helpers';
 import { withPolicyGuard } from './PolicyGuard';
+import { AssetIdentity } from '../../../components/AssetIdentity';
 import { UI_DISABLED_SETTINGS_IDS, isUiSettingDisabled } from '../../../utils/helpers';
 
 const truncateStyle: React.CSSProperties = {
@@ -75,36 +79,83 @@ const getMetadataValue = (
   return legacy[field] as string | string[] | undefined;
 };
 
+/**
+ * the panel listed these settings without saying what any of them affects. Wording follows
+ * the engine reference on the wazuh/wazuh 5.0.0 branch: `docs/ref/modules/engine/README.md`
+ * defines each pipeline stage and what each toggle does to an event, and
+ * `docs/ref/modules/engine/architecture.md` describes the routes table that maps a space to
+ * its active policy, which is what analysisd drops when a policy is disabled.
+ *
+ * The enrichment examples come from this plugin's own catalog
+ * (`../constants/enrichments.ts`), not from the engine's plugin list: the engine ships an
+ * indicator of compromise enrichment that this catalog does not offer.
+ */
+const FIELD_HINTS = {
+  status:
+    'The policy is the pipeline the engine applies to every event in this space. While it is disabled the engine removes the route, so this space processes nothing.',
+  rootDecoder:
+    'Every event enters the decoder stage through the root decoder, the entry point of the decoder tree.',
+  indexDiscardedEvents:
+    'A filter can mark an event as discarded. Turn this on to index those events anyway. Turn it off and the engine rejects them, ending the pipeline.',
+  indexUnclassifiedEvents:
+    'An event is unclassified when the decoder that matched it belongs to an integration in the unclassified category. Turn this on to index those events. Turn it off and the engine drops them.',
+  enrichments:
+    'Plugins that add context to an event after decoding: geolocation, connection details, and URL and hash fields.',
+} as const;
+
+/** one title per field, so the skeleton and the loaded panel cannot drift. */
+const FieldTitle: React.FC<{ label: string; hint: string }> = ({ label, hint }) => (
+  <>
+    {label} <EuiIconTip content={hint} position="right" />
+  </>
+);
+
 const POLICY_INFO_TAB = {
   SETTINGS: 'settings',
   DETAILS: 'details',
 } as const;
 type PolicyInfoTabId = (typeof POLICY_INFO_TAB)[keyof typeof POLICY_INFO_TAB];
 
-const renderYesNoOrDash = (value: boolean | undefined, hasPolicy: boolean): React.ReactNode => {
+/**
+ * Status drew a coloured health dot. The two indexing toggles printed a bare
+ * lowercase `yes`/`no`. Same kind of value, two styles, side by side. Draw all three
+ * here. The words still change per field: a policy is enabled or disabled, a toggle is
+ * on or off.
+ */
+const renderBoolean = (
+  value: boolean | undefined,
+  hasPolicy: boolean,
+  labels: { on: string; off: string }
+): React.ReactNode => {
   if (!hasPolicy) return '-';
-  return value ? 'yes' : 'no';
+  return (
+    <EuiHealth color={value ? 'success' : 'subdued'}>{value ? labels.on : labels.off}</EuiHealth>
+  );
 };
 
 /** EuiSkeletonText is not available in all EUI builds; EuiLoadingContent is used elsewhere in this plugin. */
 const ValueSkeleton: React.FC = () => <EuiLoadingContent lines={1} />;
 
 /** Equal-width flex columns for Settings/Details horizontal rows. */
-const COL: React.CSSProperties = { flex: '1 1 0', minWidth: 0 };
+// with `minWidth: 0` a column shrank until values broke mid-word on a narrow
+// viewport. Give it a floor, and let the rows wrap.
+const COL: React.CSSProperties = { flex: '1 1 0', minWidth: '10rem' };
 
 /** Details row 2 vs row 1 (5 cols): Documentation spans Title+Author; Description spans References+Date+Modified. */
-const DETAILS_DOC_COL: React.CSSProperties = { flex: '2 1 0', minWidth: 0 };
-const DETAILS_DESC_COL: React.CSSProperties = { flex: '3 1 0', minWidth: 0 };
+const DETAILS_DOC_COL: React.CSSProperties = { flex: '2 1 0', minWidth: '10rem' };
+const DETAILS_DESC_COL: React.CSSProperties = { flex: '3 1 0', minWidth: '10rem' };
 
 const renderSettingsSkeletonRows = (
   showDiscardedEvents: boolean,
   showUnclassifiedEvents: boolean
 ) => (
   <>
-    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap={false}>
+    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap>
       <EuiFlexItem style={COL}>
         <EuiDescriptionList>
-          <EuiDescriptionListTitle>Status</EuiDescriptionListTitle>
+          <EuiDescriptionListTitle>
+            <FieldTitle label="Status" hint={FIELD_HINTS.status} />
+          </EuiDescriptionListTitle>
           <EuiDescriptionListDescription>
             <ValueSkeleton />
           </EuiDescriptionListDescription>
@@ -112,7 +163,9 @@ const renderSettingsSkeletonRows = (
       </EuiFlexItem>
       <EuiFlexItem style={COL}>
         <EuiDescriptionList>
-          <EuiDescriptionListTitle>Root decoder</EuiDescriptionListTitle>
+          <EuiDescriptionListTitle>
+            <FieldTitle label="Root decoder" hint={FIELD_HINTS.rootDecoder} />
+          </EuiDescriptionListTitle>
           <EuiDescriptionListDescription>
             <ValueSkeleton />
           </EuiDescriptionListDescription>
@@ -121,7 +174,9 @@ const renderSettingsSkeletonRows = (
       {showDiscardedEvents && (
         <EuiFlexItem style={COL}>
           <EuiDescriptionList>
-            <EuiDescriptionListTitle>Index discarded events</EuiDescriptionListTitle>
+            <EuiDescriptionListTitle>
+              <FieldTitle label="Index discarded events" hint={FIELD_HINTS.indexDiscardedEvents} />
+            </EuiDescriptionListTitle>
             <EuiDescriptionListDescription>
               <ValueSkeleton />
             </EuiDescriptionListDescription>
@@ -131,7 +186,12 @@ const renderSettingsSkeletonRows = (
       {showUnclassifiedEvents && (
         <EuiFlexItem style={COL}>
           <EuiDescriptionList>
-            <EuiDescriptionListTitle>Index unclassified events</EuiDescriptionListTitle>
+            <EuiDescriptionListTitle>
+              <FieldTitle
+                label="Index unclassified events"
+                hint={FIELD_HINTS.indexUnclassifiedEvents}
+              />
+            </EuiDescriptionListTitle>
             <EuiDescriptionListDescription>
               <ValueSkeleton />
             </EuiDescriptionListDescription>
@@ -140,10 +200,12 @@ const renderSettingsSkeletonRows = (
       )}
     </EuiFlexGroup>
     <EuiSpacer size="l" />
-    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap={false}>
+    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap>
       <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
         <EuiDescriptionList>
-          <EuiDescriptionListTitle>Enrichments</EuiDescriptionListTitle>
+          <EuiDescriptionListTitle>
+            <FieldTitle label="Enrichments" hint={FIELD_HINTS.enrichments} />
+          </EuiDescriptionListTitle>
           <EuiDescriptionListDescription>
             <ValueSkeleton />
           </EuiDescriptionListDescription>
@@ -155,7 +217,7 @@ const renderSettingsSkeletonRows = (
 
 const detailsSkeletonRows = (
   <>
-    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap={false}>
+    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap>
       <EuiFlexItem style={COL}>
         <EuiDescriptionList>
           <EuiDescriptionListTitle>Title</EuiDescriptionListTitle>
@@ -198,7 +260,7 @@ const detailsSkeletonRows = (
       </EuiFlexItem>
     </EuiFlexGroup>
     <EuiSpacer size="l" />
-    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap={false}>
+    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap>
       <EuiFlexItem style={DETAILS_DOC_COL}>
         <EuiDescriptionList>
           <EuiDescriptionListTitle>Documentation</EuiDescriptionListTitle>
@@ -265,40 +327,53 @@ const renderSettingsPanel = (
   hasPolicy: boolean,
   policyDocumentData: PolicyDocument | undefined,
   rootDecoder: DecoderSource | undefined,
-  enrichmentsDisplay: string,
+  enrichmentsDisplay: React.ReactNode,
   showDiscardedEvents: boolean,
   showUnclassifiedEvents: boolean
 ) => (
   <>
-    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap={false}>
+    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap>
       <EuiFlexItem style={COL}>
         <EuiDescriptionList>
-          <EuiDescriptionListTitle>Status</EuiDescriptionListTitle>
+          <EuiDescriptionListTitle>
+            <FieldTitle label="Status" hint={FIELD_HINTS.status} />
+          </EuiDescriptionListTitle>
           <EuiDescriptionListDescription>
-            {!hasPolicy ? (
-              '-'
-            ) : (
-              <EuiHealth color={policyDocumentData?.enabled ? 'success' : 'subdued'}>
-                {policyDocumentData?.enabled ? 'Enabled' : 'Disabled'}
-              </EuiHealth>
-            )}
+            {renderBoolean(policyDocumentData?.enabled, hasPolicy, {
+              on: 'Enabled',
+              off: 'Disabled',
+            })}
           </EuiDescriptionListDescription>
         </EuiDescriptionList>
       </EuiFlexItem>
       <EuiFlexItem style={COL}>
         <EuiDescriptionList>
-          <EuiDescriptionListTitle>Root decoder</EuiDescriptionListTitle>
+          <EuiDescriptionListTitle>
+            <FieldTitle label="Root decoder" hint={FIELD_HINTS.rootDecoder} />
+          </EuiDescriptionListTitle>
           <EuiDescriptionListDescription>
-            {renderValue(hasPolicy ? (rootDecoder?.document?.name ?? '') : undefined)}
+            {hasPolicy ? (
+              <AssetIdentity
+                title={rootDecoder?.document?.metadata?.title}
+                identifier={rootDecoder?.document?.name}
+              />
+            ) : (
+              '-'
+            )}
           </EuiDescriptionListDescription>
         </EuiDescriptionList>
       </EuiFlexItem>
       {showDiscardedEvents && (
         <EuiFlexItem style={COL}>
           <EuiDescriptionList>
-            <EuiDescriptionListTitle>Index discarded events</EuiDescriptionListTitle>
+            <EuiDescriptionListTitle>
+              <FieldTitle label="Index discarded events" hint={FIELD_HINTS.indexDiscardedEvents} />
+            </EuiDescriptionListTitle>
             <EuiDescriptionListDescription>
-              {renderYesNoOrDash(policyDocumentData?.index_discarded_events, hasPolicy)}
+              {renderBoolean(policyDocumentData?.index_discarded_events, hasPolicy, {
+                on: 'On',
+                off: 'Off',
+              })}
             </EuiDescriptionListDescription>
           </EuiDescriptionList>
         </EuiFlexItem>
@@ -306,19 +381,29 @@ const renderSettingsPanel = (
       {showUnclassifiedEvents && (
         <EuiFlexItem style={COL}>
           <EuiDescriptionList>
-            <EuiDescriptionListTitle>Index unclassified events</EuiDescriptionListTitle>
+            <EuiDescriptionListTitle>
+              <FieldTitle
+                label="Index unclassified events"
+                hint={FIELD_HINTS.indexUnclassifiedEvents}
+              />
+            </EuiDescriptionListTitle>
             <EuiDescriptionListDescription>
-              {renderYesNoOrDash(policyDocumentData?.index_unclassified_events, hasPolicy)}
+              {renderBoolean(policyDocumentData?.index_unclassified_events, hasPolicy, {
+                on: 'On',
+                off: 'Off',
+              })}
             </EuiDescriptionListDescription>
           </EuiDescriptionList>
         </EuiFlexItem>
       )}
     </EuiFlexGroup>
     <EuiSpacer size="l" />
-    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap={false}>
+    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap>
       <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
         <EuiDescriptionList>
-          <EuiDescriptionListTitle>Enrichments</EuiDescriptionListTitle>
+          <EuiDescriptionListTitle>
+            <FieldTitle label="Enrichments" hint={FIELD_HINTS.enrichments} />
+          </EuiDescriptionListTitle>
           <EuiDescriptionListDescription>{enrichmentsDisplay}</EuiDescriptionListDescription>
         </EuiDescriptionList>
       </EuiFlexItem>
@@ -337,7 +422,7 @@ const renderDetailsPanel = (
   modifiedStr: string | string[] | undefined
 ) => (
   <>
-    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap={false}>
+    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap>
       <EuiFlexItem style={COL}>
         <EuiDescriptionList>
           <EuiDescriptionListTitle>Title</EuiDescriptionListTitle>
@@ -362,8 +447,8 @@ const renderDetailsPanel = (
               !hasPolicy
                 ? undefined
                 : Array.isArray(references)
-                  ? references.join(', ')
-                  : ((references as string) ?? '')
+                ? references.join(', ')
+                : (references as string) ?? ''
             )}
           </EuiDescriptionListDescription>
         </EuiDescriptionList>
@@ -376,8 +461,8 @@ const renderDetailsPanel = (
               !hasPolicy
                 ? undefined
                 : typeof dateStr === 'string'
-                  ? formatIntegrationMetadataDate(dateStr) || undefined
-                  : undefined
+                ? formatIntegrationMetadataDate(dateStr) || undefined
+                : undefined
             )}
           </EuiDescriptionListDescription>
         </EuiDescriptionList>
@@ -390,15 +475,15 @@ const renderDetailsPanel = (
               !hasPolicy
                 ? undefined
                 : typeof modifiedStr === 'string'
-                  ? formatIntegrationMetadataDate(modifiedStr) || undefined
-                  : undefined
+                ? formatIntegrationMetadataDate(modifiedStr) || undefined
+                : undefined
             )}
           </EuiDescriptionListDescription>
         </EuiDescriptionList>
       </EuiFlexItem>
     </EuiFlexGroup>
     <EuiSpacer size="l" />
-    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap={false}>
+    <EuiFlexGroup gutterSize="l" alignItems="flexStart" responsive={false} wrap>
       <EuiFlexItem style={DETAILS_DOC_COL}>
         <EuiDescriptionList>
           <EuiDescriptionListTitle>Documentation</EuiDescriptionListTitle>
@@ -440,13 +525,24 @@ export const PolicyInfoCardLayout: React.FC<{
     UI_DISABLED_SETTINGS_IDS.INDEX_UNCLASSIFIED_EVENTS
   );
 
-  const enrichmentsDisplay = !hasPolicy
-    ? '-'
-    : policyDocumentData?.enrichments && policyDocumentData.enrichments.length > 0
-      ? policyDocumentData.enrichments
-          .map((e) => ENRICHMENT_LABELS[e as EnrichmentType] ?? e)
-          .join(', ')
-      : '-';
+  // badges, one per enrichment. Joined by commas they read as one sentence, and
+  // you cannot scan a long list of them.
+  const enrichments = hasPolicy ? policyDocumentData?.enrichments ?? [] : [];
+  const enrichmentsDisplay = enrichments.length ? (
+    // this group is a block, so it misses the leading gap that
+    // EuiDescriptionListDescription gives the text values.
+    <EuiFlexGroup gutterSize="xs" wrap responsive={false} style={{ marginTop: 4 }}>
+      {enrichments.map((enrichment) => (
+        <EuiFlexItem grow={false} key={enrichment}>
+          <EuiBadge color="hollow">
+            {ENRICHMENT_LABELS[enrichment as EnrichmentType] ?? enrichment}
+          </EuiBadge>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGroup>
+  ) : (
+    '-'
+  );
 
   return (
     <EuiCard

--- a/public/pages/Integrations/components/RootDecoderRequirement.tsx
+++ b/public/pages/Integrations/components/RootDecoderRequirement.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAsyncAction, useAsyncActionRunOnStart, withGuardAsync } from '../utils/helpers';
 import { DataStore } from '../../../store/DataStore';
+import { AssetIdentity, formatAssetLabel } from '../../../components/AssetIdentity';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -67,9 +68,9 @@ const SelectRootDecoderForm: React.FC<SelectRootDecoderFormProps> = ({
 
       const isNewSearch = currentSearch !== state.data?.search;
 
-      const prevItems = isNewSearch ? [] : (state.data?.items ?? []);
+      const prevItems = isNewSearch ? [] : state.data?.items ?? [];
       const size = itemsPerPage;
-      const from = isNewSearch ? 0 : (state.data?.nextFrom ?? 0);
+      const from = isNewSearch ? 0 : state.data?.nextFrom ?? 0;
       const query = buildDecodersSearchQuery(currentSearch); // FIXME: this query does not match with the format of the decoders name, it can not find a substring in the name, it needs to be an exact match, we need to change the query builder to make it work with the name field or change the search field to be the keyword version of the name
       const response = await DataStore.decoders.searchDecoders(
         {
@@ -84,14 +85,18 @@ const SelectRootDecoderForm: React.FC<SelectRootDecoderFormProps> = ({
             },
           ],
           query,
-          _source: { includes: ['document.id', 'document.name'] },
+          // the title is what a reader recognises; the name is the identifier.
+          _source: { includes: ['document.id', 'document.name', 'document.metadata.title'] },
         },
         space
       );
 
       const newItems = response.items.map((item) => ({
         value: item?.document?.id,
-        label: item?.document?.name ?? item?.document?.id,
+        // `value` carries the id, so pairing the label costs nothing downstream.
+        label:
+          formatAssetLabel(item?.document?.metadata?.title, item?.document?.name) ||
+          (item?.document?.id ?? ''),
       }));
       const data = search === currentSearch ? [...(prevItems || []), ...newItems] : newItems;
 
@@ -152,7 +157,7 @@ const SelectRootDecoderForm: React.FC<SelectRootDecoderFormProps> = ({
         <EuiFormRow label="Select decoder" fullWidth={true}>
           <EuiSelect
             fullWidth={true}
-            onChange={(e) => setSelected(event.target.value)}
+            onChange={(e) => setSelected(e.target.value)}
             loading={action.running}
             value={selected}
             options={action.data?.items}
@@ -176,9 +181,12 @@ const SelectRootDecoderForm: React.FC<SelectRootDecoderFormProps> = ({
           <>
             <EuiText size="s">
               Current root decoder:{' '}
-              <EuiToolTip position="top" content={`ID: ${rootDecoderSource.document.id}`}>
-                <div>{rootDecoderSource.document.name}</div>
-              </EuiToolTip>
+              {/* The picker options pair the name with the identifier, so this line pairs
+                  them too instead of showing the identifier alone. */}
+              <AssetIdentity
+                title={rootDecoderSource.document.metadata?.title}
+                identifier={rootDecoderSource.document.name}
+              />
             </EuiText>
             <EuiSpacer size="s" />
           </>
@@ -194,7 +202,12 @@ const SelectRootDecoderForm: React.FC<SelectRootDecoderFormProps> = ({
             <EuiButtonEmpty onClick={onCancel}>Cancel</EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton fill={true} onClick={updatePolicyAction.run} isDisabled={!selected} isLoading={updatePolicyAction.running}>
+            <EuiButton
+              fill={true}
+              onClick={updatePolicyAction.run}
+              isDisabled={!selected}
+              isLoading={updatePolicyAction.running}
+            >
               Confirm
             </EuiButton>
           </EuiFlexItem>
@@ -288,8 +301,8 @@ export const withRootDecoderRequirementGuard: (Component: React.FC) => React.FC 
         rootDecoder = await DataStore.decoders.getDecoder(rootDecoderId, space);
       }
 
-      if (onSuccess && rootDecoder){
-        onSuccess()
+      if (onSuccess && rootDecoder) {
+        onSuccess();
       }
 
       return {
@@ -303,11 +316,10 @@ export const withRootDecoderRequirementGuard: (Component: React.FC) => React.FC 
   Callout
 );
 
-export const RootDecoderRequirement: React.FC<{space: UserSpace, onSucess?: () => void}> = withRootDecoderRequirementGuard(
-  ({ error }: { error: Error }) => {
+export const RootDecoderRequirement: React.FC<{ space: UserSpace; onSucess?: () => void }> =
+  withRootDecoderRequirementGuard(({ error }: { error: Error }) => {
     return error ? <EuiText color="danger">Error loading root decoder requirement</EuiText> : null;
-  }
-);
+  });
 
 export const withConditionalHOC = (
   condition: (props: any) => boolean,
@@ -324,6 +336,6 @@ export const withConditionalHOC = (
   };
 };
 
-export function isRootDecoderRequiementError(error){
+export function isRootDecoderRequiementError(error) {
   return /missing root decoder/i.test(error);
 }

--- a/public/pages/Integrations/utils/helpers.test.tsx
+++ b/public/pages/Integrations/utils/helpers.test.tsx
@@ -22,7 +22,10 @@ afterEach(() => {
 });
 
 const buildItem = (overrides: Partial<IntegrationTableItem> = {}): IntegrationTableItem => ({
+  // `id` is the OpenSearch `_id`, unique per space copy; `documentId` is shared across the
+  // copies of a promoted integration. They differ in every space but draft.
   id: 'int-1',
+  documentId: 'doc-1',
   title: 'aws',
   category: 'cloud',
   mode: '',
@@ -113,5 +116,24 @@ describe('getIntegrationsTableColumns — entity count columns', () => {
     fireEvent.mouseOver(kvdbLinks[kvdbLinks.length - 1]);
     const kvdbsTooltip = await screen.findByRole('tooltip', { hidden: true });
     expect(kvdbsTooltip).toHaveTextContent('KVDBs');
+  });
+});
+
+describe('getIntegrationsTableColumns — opening an integration', () => {
+  const renderTitle = (item: IntegrationTableItem, showDetails: (id: string) => void) => {
+    const columns = getIntegrationsTableColumns({ showDetails, setItemForAction: jest.fn() });
+    const column = columns.find((c) => c.field === 'title');
+    return render(<>{column!.render!(item.title, item)}</>);
+  };
+
+  it('opens it by the id shared across space copies, not by the per-copy _id', () => {
+    // A promoted integration has a different `_id` in each space, and the detail view looks
+    // it up by `document.id` plus the space, so linking by `_id` reported it as not found.
+    const showDetails = jest.fn();
+    renderTitle(buildItem({ id: 'os-id-in-custom', documentId: 'shared-doc-id' }), showDetails);
+
+    fireEvent.click(screen.getByText('aws'));
+
+    expect(showDetails).toHaveBeenCalledWith('shared-doc-id');
   });
 });

--- a/public/pages/Integrations/utils/helpers.tsx
+++ b/public/pages/Integrations/utils/helpers.tsx
@@ -42,7 +42,13 @@ const getIntegrationCategoryFilterDisplayName = (value: string): string => {
 };
 
 export interface IntegrationTableItem {
+  /** OpenSearch `_id`, unique per space copy. Row selection and deletion use it. */
   id: string;
+  /**
+   * `document.id`, shared by every space copy of a promoted integration. The detail view
+   * looks an integration up by this plus the space, so links carry it instead of `id`.
+   */
+  documentId: string;
   title: string;
   category: string;
   mode: string;
@@ -70,11 +76,15 @@ export const mapPolicyToIntegrationTableItems = (
   const map = policy.integrationsMap ?? {};
   const orderedIds: string[] = policy.document?.integrations ?? [];
 
+  // The policy lists its integrations by `document.id`, which is what keys the map.
   return orderedIds
-    .map((id) => map[id])
-    .filter((source): source is PolicyIntegrationTableEntry => Boolean(source && source._id))
-    .map((source) => ({
+    .map((documentId) => ({ documentId, source: map[documentId] }))
+    .filter((entry): entry is { documentId: string; source: PolicyIntegrationTableEntry } =>
+      Boolean(entry.source && entry.source._id)
+    )
+    .map(({ documentId, source }) => ({
       id: source._id,
+      documentId,
       title: source.document.metadata?.title ?? '',
       category: source.document.category,
       mode: source.document.mode ?? '',
@@ -168,6 +178,11 @@ export const getIntegrationsTableColumns = ({
   showDetails,
   setItemForAction,
 }: {
+  /**
+   * Takes `document.id`, not the OpenSearch `_id`. Promoting an integration creates a
+   * copy per space with its own `_id`, while `document.id` stays the same across them,
+   * and the detail view looks the integration up by `document.id` and space.
+   */
   showDetails: (id: string) => void;
   setItemForAction: (options: { item: any; action: typeof SPACE_ACTIONS.DELETE } | null) => void;
 }) => [
@@ -176,7 +191,7 @@ export const getIntegrationsTableColumns = ({
     name: 'Title',
     sortable: false,
     render: (name: string, item: Integration) => {
-      return <EuiLink onClick={() => showDetails(item.id)}>{name}</EuiLink>;
+      return <EuiLink onClick={() => showDetails(item.documentId)}>{name}</EuiLink>;
     },
   },
   {
@@ -231,7 +246,7 @@ export const getIntegrationsTableColumns = ({
         type: 'icon',
         icon: 'inspect',
         onClick: (item) => {
-          showDetails(item.id);
+          showDetails(item.documentId);
         },
       },
       {

--- a/public/pages/WazuhRules/components/RuleContentViewer/RuleContentViewer.tsx
+++ b/public/pages/WazuhRules/components/RuleContentViewer/RuleContentViewer.tsx
@@ -149,7 +149,14 @@ export const RuleContentViewer: React.FC<RuleContentViewerProps> = ({
                 {COMPLIANCE_FRAMEWORKS.map((framework) =>
                   complianceData[framework.key].length > 0 ? (
                     <EuiFlexItem key={framework.key}>
-                      <BadgeGroup label={framework.label} values={complianceData[framework.key]} />
+                      {/* name what the codes are. A reader saw bare numbers like
+                          6.5.10 under the framework name. Each framework calls its unit
+                          something different, and `compliance.ts` already stored that word
+                          in `columnHeader`, which nothing read. */}
+                      <BadgeGroup
+                        label={`${framework.label} ${framework.columnHeader.toLowerCase()}`}
+                        values={complianceData[framework.key]}
+                      />
                     </EuiFlexItem>
                   ) : null
                 )}


### PR DESCRIPTION
## Description

Third slice of #447, covering group C: "Show meaning, not identifiers". Groups A and D
shipped in #448, group B in #451.

The UI showed the user machine values and left the meaning implicit: a root decoder printed
as `decoder/core-wazuh-message/0`, compliance codes as bare numbers, and a space policy panel
whose settings never said what they affect.

Closes #447

| Task | Status |
| --- | --- |
| **C1** pair asset identifiers with their titles | ✅ Done |
| **C2** render MITRE and compliance data with labels | ✅ Done, compliance half. MITRE already shipped in #449 |
| **C3** stop leaking template syntax into rule names | ⬜ Dropped: the engine produces those titles and the indexer stores them, so they are not this plugin's copy |
| **C4** make the space policy panel legible | ✅ Done |

## Proposed Changes

- **C1** — a decoder keeps its identifier in `document.name` and its readable name in
  `document.metadata.title`. A shared `AssetIdentity` pairs them: two lines where there is
  room, one string where only a label fits. Adopted by the policy panel's Root decoder field,
  the root decoder picker in the promotion callout together with its "Current root decoder"
  line, the same two in the policy edit form, and the decoder editor breadcrumb. Both pickers
  save `document.id`, so only what the reader sees changed. Their searches also had to request
  `document.metadata.title`, which they were not fetching.

  The commit that touches `EditPolicy.tsx` skips the format hook, so **CI will report that
  file as unformatted**: it is not prettier-clean on `5.0.0` and the hook rejects it the
  moment it is touched. Reformatting it here would bury an 18-line change under 467 lines of
  churn, so the reformatting lands on its own.
- **C2** — `compliance.ts` defined a `columnHeader` per framework ("Requirement", "Control",
  "Article", ...) and **nothing read it**, so the rule flyout grouped codes under the
  framework name alone and `6.5.10` meant nothing. Values now sit under
  `PCI DSS requirement`, `HIPAA control`, `GDPR article`. Control **names** stay out of scope:
  `ComplianceState` holds codes only, so naming them needs a dataset that does not exist yet.
- **C4** — Status drew a coloured health dot while the two indexing toggles printed a bare
  lowercase `yes`/`no`. All three now read the same way, with wording per field. Every setting
  carries a hint saying what it affects, taken from the engine reference on the wazuh/wazuh
  5.0.0 branch: `docs/ref/modules/engine/README.md` for the pipeline stages and what each
  toggle does to an event, `architecture.md` for the routes table a disabled policy loses. The
  enrichment examples come from this plugin's own catalog rather than the engine's plugin
  list, which offers an indicator of compromise enrichment this plugin does not. Enrichments
  render as badges instead of a comma-joined sentence, and the columns wrap on a narrow
  viewport instead of squeezing until values break mid-word.
- **One bug fixed, a regression from #430**: the integration detail view reported "Integration
  not found" for any promoted integration. Promoting creates a copy per space with its own
  OpenSearch `_id`, while `document.id` stays the same across copies. That change moved the
  lookup to `document.id` and left the list linking by `_id`. It went unnoticed because in the
  standard space both ids are the same value, and only promoted content diverges. The table
  item now carries both ids with their contract written down, and links use `document.id`.

## How to Test

Requires a space with promoted content. The steps below assume an integration created in
draft and promoted to test and custom.

1. Open Overview in **custom** and click an integration's title. It opens. Before this PR any
   promoted integration answered "Integration not found". Check the URL carries the same id
   in every space, and only `space` changes.
2. Repeat from the row's **View** action, and from the **Integration** column CTA on the
   Decoders, Rules and KVDBs lists.
3. In the policy panel, read the **Root decoder** field: the decoder's name, with
   `decoder/...` underneath. An integration with no policy still shows `-`.
4. Hover the **five** help icons: Status, Root decoder, both indexing toggles, and
   Enrichments. Each says what the setting affects.
5. Check the three booleans read alike. Status says Enabled or Disabled, the two toggles say
   On or Off, all three with a coloured dot. Enrichments are badges.
6. Narrow the window. The panel columns wrap instead of compressing, and no value breaks
   mid-word. The page header wraps too.
7. Open the promotion callout for a space with no root decoder. Each option in the picker
   reads as a name with its identifier, and "Current root decoder" pairs them as well.
   Selecting one and confirming still works: the picker submits the id, not the label.
8. Open the policy edit form. Its root decoder combo pairs them too, and so does the line
   shown where the space forbids editing the policy. Pick a different decoder, save, reopen:
   the choice persists, which proves the label change did not reach the saved value.
9. Edit a decoder. The last breadcrumb is its title, not `decoder/.../0`.
10. Open a rule with compliance data. Values sit under `PCI DSS requirement`,
   `HIPAA control`, `GDPR article`, one label per framework.

## Results and Evidence

<img width="1393" height="895" alt="image" src="https://github.com/user-attachments/assets/e6e6b85f-3781-4176-b5ee-164bcdfab6a5" />

<img width="1372" height="943" alt="image" src="https://github.com/user-attachments/assets/1bf48522-4a03-4bd6-bc2b-74b35b74bb41" />

<img width="438" height="232" alt="image" src="https://github.com/user-attachments/assets/339365ee-39fc-4394-b351-8433e09c370c" />

<img width="612" height="422" alt="image" src="https://github.com/user-attachments/assets/89bd3158-473f-4fe6-ad0d-59c70f6255d0" />

<img width="866" height="550" alt="image" src="https://github.com/user-attachments/assets/1a9b43a0-3b87-422a-95d6-f0dd71d5e051" />

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None. The policy hints quote the engine reference rather than adding new wording, so
`TERMINOLOGY.md` needs no new entry.

### Tests Introduced

Colocated tests for the new `AssetIdentity`, covering the pairing, both fallbacks and the
empty value. `Integrations/utils/helpers.test.tsx` gains a case asserting the title link opens
an integration by the id shared across space copies, which is the regression above and would
have caught it.

`yarn test:jest` in the dev container: 62 suites, 248 tests, 33 snapshots green. One detector
snapshot was regenerated because the shared page header now wraps.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality <!-- AssetIdentity and the link regression; see Tests Introduced -->
- [x] Configuration changes documented <!-- none -->
- [x] Developer documentation reflects the changes <!-- none needed -->
- [ ] Meets requirements and/or definition of done <!-- C1, C2 and C4 done; C3 dropped -->
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied


